### PR TITLE
Allow ids beeing a string (or number)

### DIFF
--- a/packages/react-admin-core/src/useTableQuery.ts
+++ b/packages/react-admin-core/src/useTableQuery.ts
@@ -6,7 +6,7 @@ import ISelectionApi from "./SelectionApi";
 import { IPagingActions } from "./table/pagingStrategy/PagingStrategy";
 import { ITableQueryApi } from "./TableQueryContext";
 
-interface ITableData<TRow extends { id: number } = { id: number }> {
+interface ITableData<TRow extends { id: string | number } = { id: string | number }> {
     data?: TRow[];
     totalCount?: number;
     pagingActions?: IPagingActions;


### PR DESCRIPTION
APIs might have string ids (for example GraphQL's ID type is a string)