### PR TITLE
fix realpath for macOS

### DIFF
--- a/wml-add.sh
+++ b/wml-add.sh
@@ -13,8 +13,16 @@ if [ ! -d "$1/node_modules/@vivid-planet" ]; then
     exit 1
 fi
 
-target=$(realpath "$1/node_modules/@vivid-planet");
-source=$(realpath "$(dirname "$0")")
+custom_realpath() {
+    if ! [ -x "$(command -v realpath)" ]; then
+        grealpath "$@"
+    else
+        realpath "$@"
+    fi
+}
+
+target=$(custom_realpath "$1/node_modules/@vivid-planet");
+source=$(custom_realpath "$(dirname "$0")")
 echo $target
 echo $source
 packages=( file-icons material-ui-react-select react-admin-core react-admin-date-fns react-admin-final-form-material-ui react-admin-form react-admin-layout react-admin-mui )


### PR DESCRIPTION
`realpath` is not available on macOS, use `grealpath` from `coreutils` instead for macOS.