### PR TITLE
Refetch table query on mount

### DIFF
--- a/packages/react-admin-core/src/table/useTableQuery.ts
+++ b/packages/react-admin-core/src/table/useTableQuery.ts
@@ -66,6 +66,10 @@ export function useTableQuery<TInnerData, TInnerVariables>() {
             api,
         };
 
+        React.useEffect(() => {
+            ret.refetch();
+        }, []);
+
         function changePage(vars: object) {
             // TODO
             // if (this.domRef.current) {


### PR DESCRIPTION
Makes sure when changing view (using the menu) the query automatically reloads. Apollo is smart enough to not load it twice initially.