### PR TITLE
Make TableLocalChanges independent of Apollo

### DIFF
--- a/examples/table-dnd-order/.gitignore
+++ b/examples/table-dnd-order/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/examples/table-dnd-order/package.json
+++ b/examples/table-dnd-order/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "table-dnd-order-example",
+    "version": "0.1.0",
+    "private": true,
+    "dependencies": {
+        "react": "^16.8",
+        "react-dom": "^16.8",
+        "@vivid-planet/react-admin-core": "^1.0.0-alpha.11",
+        "webpack": "^4.30.0",
+        "webpack-cli": "^3.3.1",
+        "webpack-dev-server": "^3.3.1",
+        "@types/webpack": "^4.4.27",
+        "@types/webpack-dev-server": "^3.1.5",
+        "ts-loader": "^5.4.3",
+        "ts-node": "^8.1.0",
+        "@material-ui/core": "^3.9.2"
+    },
+    "scripts": {
+        "start": "webpack-dev-server --config ./webpack.config.js --env.production=0"
+    }
+}

--- a/examples/table-dnd-order/public/index.html
+++ b/examples/table-dnd-order/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#000000" />
+        <title>React App</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="text/javascript">
+            (function() {
+                var script = document.createElement("script");
+                script.src = "/build/example.js";
+                script.async = 1;
+                document.head.appendChild(script);
+            })();
+        </script>
+    </body>
+</html>

--- a/examples/table-dnd-order/src/App.tsx
+++ b/examples/table-dnd-order/src/App.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@material-ui/core";
+import { TableColumn as Column, TableDndOrder, TableLocalChanges } from "@vivid-planet/react-admin-core";
+import * as React from "react";
+
+interface IRow {
+    id: string; // TODO add support for number in TableLocalChanges
+    pos: number;
+    foo1: string;
+    foo2: string;
+}
+export default function App() {
+    const data: IRow[] = [{ id: "1", pos: 1, foo1: "blub", foo2: "blub" }, { id: "2", pos: 2, foo1: "blub", foo2: "blub" }];
+    return (
+        <TableLocalChanges
+            data={data}
+            onSubmit={async changes => {
+                alert(JSON.stringify(changes));
+            }}
+        >
+            {({ tableLocalChangesApi, data: changedData }) => (
+                <>
+                    <TableDndOrder data={changedData} totalCount={changedData.length} sort="foo1" order="asc" moveRow={tableLocalChangesApi.moveRow}>
+                        <Column name="foo1" header="Foo1" />
+                        <Column name="foo2" header="Foo2">
+                            {row => <strong>{row.foo2}</strong>}
+                        </Column>
+                    </TableDndOrder>
+                    <Button
+                        onClick={() => {
+                            tableLocalChangesApi.submitLocalDataChanges();
+                        }}
+                    >
+                        Submit
+                    </Button>
+                </>
+            )}
+        </TableLocalChanges>
+    );
+}

--- a/examples/table-dnd-order/src/index.tsx
+++ b/examples/table-dnd-order/src/index.tsx
@@ -1,0 +1,14 @@
+import { createMuiTheme } from "@material-ui/core";
+import { MuiThemeProvider as ThemeProvider } from "@vivid-planet/react-admin-mui";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import App from "./App";
+
+const theme = createMuiTheme({});
+
+ReactDOM.render(
+    <ThemeProvider theme={theme}>
+        <App />
+    </ThemeProvider>,
+    document.getElementById("root"),
+);

--- a/examples/table-dnd-order/tsconfig.json
+++ b/examples/table-dnd-order/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "sourceMap": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "module": "commonjs",
+        "target": "es5",
+        "jsx": "react",
+        "lib": ["dom", "es2015", "es2016", "es2017", "esnext.asynciterable"],
+        "baseUrl": "./",
+        "paths": {
+            "app/*": ["src/*"]
+        }
+    },
+    "compileOnSave": false
+}

--- a/examples/table-dnd-order/webpack.config.js
+++ b/examples/table-dnd-order/webpack.config.js
@@ -1,0 +1,43 @@
+const path = require("path");
+
+module.exports = {
+    mode: "development",
+    optimization: {
+        usedExports: true,
+    },
+    entry: {
+        example: ["./src/index.tsx"],
+    },
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                exclude: /node_modules/,
+                loader: "ts-loader",
+            },
+        ],
+    },
+    resolve: {
+        modules: ["node_modules"],
+        descriptionFiles: ["package.json"],
+        mainFields: ["browser", "module", "main"],
+        extensions: ["*", ".mjs", ".js", ".jsx", ".ts", ".tsx"],
+        alias: {
+            app: path.resolve(__dirname, "src/"),
+        },
+    },
+    output: {
+        path: path.resolve(__dirname, "build"),
+        filename: "[name].js",
+        publicPath: "/build/",
+    },
+    devServer: {
+        host: "0.0.0.0",
+        port: 8080,
+        contentBase: path.join(__dirname, "public"),
+        historyApiFallback: true,
+        headers: {
+            "Access-Control-Allow-Origin": "*",
+        },
+    },
+};

--- a/packages/react-admin-core/src/table/TableDndOrder.tsx
+++ b/packages/react-admin-core/src/table/TableDndOrder.tsx
@@ -86,7 +86,7 @@ interface IRowCollectedProps {
 }
 class DndOrderRow extends React.Component<IRowProps & IRowCollectedProps> {
     public render() {
-        const { connectDropTarget, connectDragSource, connectDragPreview, isDragging, moveRow, ...rest } = this.props;
+        const { connectDropTarget, connectDragSource, connectDragPreview, isDragging, moveRow, id, ...rest } = this.props;
         const opacity = isDragging ? 0 : 1;
         return (
             <RootRef rootRef={this.handleRootRef}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2049,7 +2049,7 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-chokidar@^2.0.2, chokidar@^2.0.4, chokidar@^2.1.5:
+chokidar@^2.0.2, chokidar@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.5.tgz#0ae8434d962281a5f56c72869e79cb6d9d86ad4d"
   integrity sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==
@@ -3416,20 +3416,6 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
-
-fork-ts-checker-webpack-plugin@^1.2.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.3.2.tgz#5de6cfd84dc175e95ace01d25e751956a5dc24e0"
-  integrity sha512-wy1JEZvzI4v+NYB+ybbbZX3jkb9FUWLr7ue8b2ZEDDG3Aw6uPqI+l7bFEYGwvAYFS+SIyoobTtK5mhwvEbIkdA==
-  dependencies:
-    babel-code-frame "^6.22.0"
-    chalk "^2.4.1"
-    chokidar "^2.0.4"
-    micromatch "^3.1.10"
-    minimatch "^3.0.4"
-    semver "^5.6.0"
-    tapable "^1.0.0"
-    worker-rpc "^0.1.0"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -5177,11 +5163,6 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
-
-microevent.ts@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.0.tgz#390748b8a515083e6b63cd5112a3f18c2fe0eba8"
-  integrity sha1-OQdIuKUVCD5rY81REqPxjC/g66g=
 
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
@@ -7942,11 +7923,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript-plugin-styled-components@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/typescript-plugin-styled-components/-/typescript-plugin-styled-components-1.4.2.tgz#e9599dca04eba76eae7a69af363220dc46ba1605"
-  integrity sha512-WPh/ECRNh6VxIM9ZsgSZAntzherVnYSRUsU28y4vbFfzg3TIFTLxfoUmtDML6zMNrJksq0t3RbkwBZfqOlWaXQ==
-
 typescript@^3.4.1:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
@@ -8357,13 +8333,6 @@ worker-farm@^1.5.2:
   integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
   dependencies:
     errno "~0.1.7"
-
-worker-rpc@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/worker-rpc/-/worker-rpc-0.1.0.tgz#5f1258dca3d617cd18ca86587f8a05ac0eebd834"
-  integrity sha1-XxJY3KPWF80YyoZYf4oFrA7r2DQ=
-  dependencies:
-    microevent.ts "~0.1.0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
- add onSubmit method (similar to FinalForm)
- remove updateMutation prop
- add helper method to call from onSubmit that does the same with updateMutation as previously

Also add an example showing the usage of TableDndOrder + TableLocalChanges

This is an incompatible change but so far there are no uses of TableDndOrder + TableLocalChanges