### PR TITLE
Don't pass custom prop to TableRow

### DIFF
--- a/packages/react-admin-core/src/table/Table.sc.tsx
+++ b/packages/react-admin-core/src/table/Table.sc.tsx
@@ -1,5 +1,6 @@
 import TableHead from "@material-ui/core/TableHead";
 import TableRow, { TableRowProps } from "@material-ui/core/TableRow";
+import * as React from "react";
 import styled from "styled-components";
 
 export const StyledTableHead = styled(TableHead)`
@@ -10,7 +11,7 @@ interface ITableRowProps extends TableRowProps {
     hideTableHead: boolean;
 }
 
-export const StyledTableBodyRow = styled(TableRow)<ITableRowProps>`
+export const StyledTableBodyRow = styled<ITableRowProps>(({ hideTableHead, ...rest }) => <TableRow {...rest} />)`
     &:nth-child(${props => (props.hideTableHead ? "odd" : "even")}) {
         background-color: ${props => props.theme.palette.grey["50"]};
     }


### PR DESCRIPTION
this caused the following warning:
React does not recognize the `hideTableHead` prop on a DOM element.

Warning got introduced in #40