### PR TITLE
make hide table head optional

### DIFF
--- a/packages/react-admin-core/src/table/Table.sc.tsx
+++ b/packages/react-admin-core/src/table/Table.sc.tsx
@@ -9,7 +9,7 @@ export const StyledTableHead = styled(TableHead)`
 
 export interface ITableBodyRowProps extends TableRowProps {
     index: number;
-    hideTableHead: boolean;
+    hideTableHead?: boolean;
 }
 
 export const TableBodyRow = styled<ITableBodyRowProps>(({ index, hideTableHead, ...rest }) => <TableRow {...rest} />)`


### PR DESCRIPTION
Prop does not need to be required.

This also "fixes" the currently broken example 'table-expanded-row'