### PR TITLE
Don't parse date using new Date(string) as that breaks in Safari

### DIFF
--- a/packages/react-admin-form/src/DatePicker.tsx
+++ b/packages/react-admin-form/src/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { format } from "date-fns";
+import { format, isValid, parse, parseISO } from "date-fns";
 import * as de from "date-fns/locale/de";
 import * as React from "react";
 import DatePickerOrig, { ReactDatePickerProps, registerLocale } from "react-datepicker";
@@ -10,8 +10,8 @@ import { StyledInput } from "./Input";
 
 registerLocale("de", de);
 
-const onChangeAdapter = (origOnChange: <T>(event: React.ChangeEvent<T> | any) => void, showTimeSelect: boolean, date?: Date) => {
-    origOnChange(date && format(date, showTimeSelect ? "yyyy-MM-dd HH:mm:ss" : "yyyy-MM-dd"));
+const onChangeAdapter = (origOnChange: <T>(event: React.ChangeEvent<T> | any) => void, valueFormat: string, date?: Date) => {
+    origOnChange(date && format(date, valueFormat));
 };
 
 interface IProps extends FieldRenderProps, ReactDatePickerProps {
@@ -23,12 +23,24 @@ export const DatePicker: React.FunctionComponent<IProps> = ({ input: { value, on
             width,
         },
     };
+    const valueFormat = rest.showTimeSelect ? "yyyy-MM-dd HH:mm:ss" : "yyyy-MM-dd";
+
+    let parsedValue: Date | null = value;
+    if (parsedValue) {
+        parsedValue = parseISO(value);
+        if (!isValid(parsedValue)) {
+            parsedValue = parse(value, valueFormat, new Date());
+        }
+        if (!isValid(parsedValue)) {
+            parsedValue = null;
+        }
+    }
     return (
         <sc.DatePickerRoot>
             <DatePickerOrig
                 locale="de"
-                selected={value ? new Date(value) : null}
-                onChange={onChangeAdapter.bind(this, onChange, !!rest.showTimeSelect)}
+                selected={parsedValue}
+                onChange={onChangeAdapter.bind(this, onChange, valueFormat)}
                 customInput={<StyledInput type="text" {...inputProps} />}
                 {...restInput}
                 {...rest}


### PR DESCRIPTION
For now the following formats are supported:
- 2018-01-04 03:50:00
- 2018-01-04T03:50:00+02:00