### PR TITLE
Downgrade query-string to 5 to support es5 (ie11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "@types/recompose": "^0.30.6",
         "@types/styled-components": "4.1.8",
         "@types/uuid": "^3.4.4",
+        "@types/query-string": "^5.1.0",
         "@vivid-planet/vplint": "^1.0.2",
         "apollo-client": "^2.6.3",
         "date-fns": "^2.0.0-alpha.37",

--- a/packages/react-admin-core/package.json
+++ b/packages/react-admin-core/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "debounce": "^1.2.0",
         "lodash.isequal": "^4.5.0",
-        "query-string": "^6.8.1",
+        "query-string": "^5.1.1",
         "react-dnd": "^8.0.3",
         "react-dnd-html5-backend": "^8.0.3",
         "uuid": "^3.3.2"


### PR DESCRIPTION
For some very weird reason query-string decided to shop es6 compatible code only in their npm package.