### PR TITLE
Enable skipLibCheck to fix build for react-dnd-cjs

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,7 +7,8 @@
         "noImplicitAny": true,
         "sourceMap": true,
         "strictNullChecks": true,
-        "target": "es5"
+        "target": "es5",
+        "skipLibCheck": true
     },
     "compileOnSave": false
 }


### PR DESCRIPTION
Else the build fails with Cannot find module 'dnd-core' (as we use dnd-core-cjs)