### PR TITLE
Fix collapsible item

### DIFF
--- a/packages/react-admin-mui/src/menu/Item.tsx
+++ b/packages/react-admin-mui/src/menu/Item.tsx
@@ -14,14 +14,7 @@ export interface IMenuItemProps extends IMenuLevel {
 
 type MuiListItemProps = Pick<ListItemProps, Exclude<keyof ListItemProps, "innerRef" | "button">> & { component?: React.ElementType };
 
-export const MenuItem: React.FunctionComponent<IMenuItemProps & MuiListItemProps> = ({
-    text,
-    icon,
-    level,
-    secondaryAction,
-    onClick,
-    ...otherProps
-}) => {
+export const MenuItem: React.FunctionComponent<IMenuItemProps & MuiListItemProps> = ({ text, icon, level, secondaryAction, ...otherProps }) => {
     const context = React.useContext(MenuContext);
     if (!context) throw new Error("Could not find context for menu");
     const hasIcon = !!icon;


### PR DESCRIPTION
The `onClick` property was mistakenly extracted from the props (it is not used here). It should be passed down to `sc.ListItem` instead.