### PR TITLE
Add Material-UI props to form elements

### DIFF
--- a/packages/react-admin-final-form-material-ui/src/Checkbox.tsx
+++ b/packages/react-admin-final-form-material-ui/src/Checkbox.tsx
@@ -1,9 +1,9 @@
-import MuiCheckbox from "@material-ui/core/Checkbox";
+import MuiCheckbox, { CheckboxProps } from "@material-ui/core/Checkbox";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
 interface IProps extends FieldRenderProps<string, HTMLInputElement> {}
 
-export const Checkbox: React.SFC<IProps> = ({ input: { checked, name, onChange, ...restInput }, meta, ...rest }) => {
+export const Checkbox: React.FunctionComponent<IProps & CheckboxProps> = ({ input: { checked, name, onChange, ...restInput }, meta, ...rest }) => {
     return <MuiCheckbox {...rest} name={name} inputProps={restInput} onChange={onChange} checked={checked} />;
 };

--- a/packages/react-admin-final-form-material-ui/src/Radio.tsx
+++ b/packages/react-admin-final-form-material-ui/src/Radio.tsx
@@ -1,9 +1,9 @@
-import MuiRadio from "@material-ui/core/Radio";
+import MuiRadio, { RadioProps } from "@material-ui/core/Radio";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
 interface IProps extends FieldRenderProps<string, HTMLInputElement> {}
 
-export const Radio: React.SFC<IProps> = ({ input: { checked, value, name, onChange, ...restInput }, meta, ...rest }) => (
+export const Radio: React.FunctionComponent<IProps & RadioProps> = ({ input: { checked, value, name, onChange, ...restInput }, meta, ...rest }) => (
     <MuiRadio {...rest} name={name} inputProps={restInput} onChange={onChange} checked={!!checked} value={value} />
 );

--- a/packages/react-admin-final-form-material-ui/src/Switch.tsx
+++ b/packages/react-admin-final-form-material-ui/src/Switch.tsx
@@ -1,9 +1,9 @@
-import MuiSwitch from "@material-ui/core/Switch";
+import MuiSwitch, { SwitchProps } from "@material-ui/core/Switch";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
 interface IProps extends FieldRenderProps<string, HTMLInputElement> {}
 
-export const Switch: React.SFC<IProps> = ({ input: { checked, name, onChange, ...restInput }, meta, ...rest }) => {
+export const Switch: React.FunctionComponent<IProps & SwitchProps> = ({ input: { checked, name, onChange, ...restInput }, meta, ...rest }) => {
     return <MuiSwitch {...rest} name={name} inputProps={restInput} onChange={onChange} checked={checked} />;
 };

--- a/packages/react-admin-final-form-material-ui/src/TextField.tsx
+++ b/packages/react-admin-final-form-material-ui/src/TextField.tsx
@@ -1,10 +1,10 @@
-import MuiTextField from "@material-ui/core/TextField";
+import MuiTextField, { TextFieldProps } from "@material-ui/core/TextField";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
 interface IProps extends FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement> {}
 
-export const TextField: React.SFC<IProps> = ({ input: { name, onChange, value, ...restInput }, meta, ...rest }) => (
+export const TextField: React.FunctionComponent<IProps & TextFieldProps> = ({ input: { name, onChange, value, ...restInput }, meta, ...rest }) => (
     <MuiTextField
         {...rest}
         name={name}


### PR DESCRIPTION
Sometimes it's handy to pass down Material-UI props such as `classes` to the Material-UI components. This already works, but the props of our custom form elements are lacking the Material-UI props, therefore causing the compilation to fail.