### PR TITLE
Date inputs: Use locale as provided by context instead of hardcoded de

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "@types/lodash.isequal": "^4.5.5",
         "@types/node": "^12.6.1",
         "@types/react": "^16.8.23",
-        "@types/react-datepicker": "^2.3.0",
+        "@types/react-datepicker": "^2.9.2",
         "@types/react-dom": "^16.8.4",
         "@types/react-router": "^5.0.3",
         "@types/react-router-dom": "^4.3.4",

--- a/packages/react-admin-form/package.json
+++ b/packages/react-admin-form/package.json
@@ -7,7 +7,7 @@
         "lib"
     ],
     "dependencies": {
-        "react-datepicker": "^2.7.0"
+        "react-datepicker": "^2.9.6"
     },
     "devDependencies": {
         "@vivid-planet/react-admin-date-fns": "^1.0.0-alpha.2",

--- a/packages/react-admin-form/src/DatePicker.tsx
+++ b/packages/react-admin-form/src/DatePicker.tsx
@@ -1,14 +1,13 @@
 import { InputBaseProps } from "@material-ui/core/InputBase";
+import { LocaleContext } from "@vivid-planet/react-admin-date-fns";
 import { format, isValid, parse, parseISO } from "date-fns";
-import * as de from "date-fns/locale/de";
 import * as React from "react";
-import DatePickerOrig, { ReactDatePickerProps, registerLocale } from "react-datepicker";
+import DatePickerOrig, { ReactDatePickerProps } from "react-datepicker";
 // tslint:disable-next-line:no-submodule-imports
 import "react-datepicker/dist/react-datepicker.css";
 import { FieldRenderProps } from "react-final-form";
 import * as sc from "./DatePicker.sc";
 import { StyledInput } from "./Input";
-registerLocale("de", de);
 
 const onChangeAdapter = (origOnChange: <T>(event: React.ChangeEvent<T> | any) => void, valueFormat: string, date?: Date) => {
     origOnChange(date && format(date, valueFormat));
@@ -25,6 +24,7 @@ class DPInput extends React.Component<InputBaseProps> {
 }
 
 export const DatePicker: React.FunctionComponent<IProps> = ({ input: { value, onChange, ...restInput }, meta, width, ...rest }) => {
+    const locale = React.useContext(LocaleContext);
     const inputProps = {
         style: {
             width,
@@ -47,7 +47,7 @@ export const DatePicker: React.FunctionComponent<IProps> = ({ input: { value, on
     return (
         <sc.DatePickerRoot>
             <DatePickerOrig
-                locale="de"
+                locale={locale}
                 selected={parsedValue}
                 onChange={onChangeAdapter.bind(this, onChange, valueFormat)}
                 customInput={<DPInput {...inputProps} />}

--- a/packages/react-admin-form/src/DateRange.tsx
+++ b/packages/react-admin-form/src/DateRange.tsx
@@ -4,13 +4,10 @@ import DateRangeIcon from "@material-ui/icons/DateRange";
 import { LocaleContext } from "@vivid-planet/react-admin-date-fns";
 import { styled } from "@vivid-planet/react-admin-mui";
 import { format } from "date-fns";
-import * as de from "date-fns/locale/de";
 import * as React from "react";
 import DatePicker, { registerLocale } from "react-datepicker";
 import { FieldRenderProps } from "react-final-form";
 import { StyledInput } from "./Input";
-
-registerLocale("de", de);
 
 const ExtendedStyledInput = styled(StyledInput)<InputBaseProps>`
     & input {
@@ -63,7 +60,7 @@ export const DateRange: React.FunctionComponent<InputBaseProps & FieldRenderProp
             >
                 <DatePicker
                     inline
-                    locale="de"
+                    locale={locale}
                     selected={startDate}
                     selectsStart
                     startDate={startDate || undefined}
@@ -78,7 +75,7 @@ export const DateRange: React.FunctionComponent<InputBaseProps & FieldRenderProp
                 />
                 <DatePicker
                     inline
-                    locale="de"
+                    locale={locale}
                     selected={endDate}
                     selectsEnd
                     startDate={startDate || undefined}


### PR DESCRIPTION
Fixes also incompatibility with newer date-fns version and locales