### PR TITLE
Add prop for pagination positioning

### DIFF
--- a/packages/react-admin-core/src/table/Table.tsx
+++ b/packages/react-admin-core/src/table/Table.tsx
@@ -122,7 +122,7 @@ export interface ITableProps<TRow extends IRow> {
     hideTableHead?: boolean;
     columns: Array<ITableColumn<TRow>>;
     sortApi?: ISortApi;
-    pagination?: "bottom" | "top" | "both" | "none";
+    paginationPosition?: "bottom" | "top" | "both";
 }
 
 function DefaultTableRow<TRow extends IRow>({ columns, row, rowProps }: ITableRowProps<TRow>) {
@@ -149,9 +149,9 @@ export class Table<TRow extends IRow> extends React.Component<ITableProps<TRow>>
             this.props.pagingInfo.attachTableRef(this.domRef);
         }
 
-        const pagination = this.props.pagination || "bottom";
-        const shouldRenderTopPagination = pagination === "top" || pagination === "both";
-        const shouldRenderBottomPagination = pagination === "bottom" || pagination === "both";
+        const paginationPosition = this.props.paginationPosition || "bottom";
+        const shouldRenderTopPagination = paginationPosition === "top" || paginationPosition === "both";
+        const shouldRenderBottomPagination = paginationPosition === "bottom" || paginationPosition === "both";
 
         return (
             <RootRef rootRef={this.domRef}>

--- a/packages/react-admin-core/src/table/Table.tsx
+++ b/packages/react-admin-core/src/table/Table.tsx
@@ -122,6 +122,7 @@ export interface ITableProps<TRow extends IRow> {
     hideTableHead?: boolean;
     columns: Array<ITableColumn<TRow>>;
     sortApi?: ISortApi;
+    pagination?: "bottom" | "top" | "both" | "none";
 }
 
 function DefaultTableRow<TRow extends IRow>({ columns, row, rowProps }: ITableRowProps<TRow>) {
@@ -148,11 +149,24 @@ export class Table<TRow extends IRow> extends React.Component<ITableProps<TRow>>
             this.props.pagingInfo.attachTableRef(this.domRef);
         }
 
+        const pagination = this.props.pagination || "bottom";
+        const shouldRenderTopPagination = pagination === "top" || pagination === "both";
+        const shouldRenderBottomPagination = pagination === "bottom" || pagination === "both";
+
         return (
             <RootRef rootRef={this.domRef}>
                 <MuiTable>
                     {!this.props.hideTableHead && (
                         <sc.StyledTableHead>
+                            {this.props.pagingInfo && shouldRenderTopPagination && (
+                                <TableRow>
+                                    <TablePagination
+                                        totalCount={this.props.totalCount}
+                                        pagingInfo={this.props.pagingInfo}
+                                        rowName={this.props.rowName}
+                                    />
+                                </TableRow>
+                            )}
                             {renderHeadTableRow({
                                 columns: this.props.columns,
                                 sortApi: this.props.sortApi,
@@ -181,7 +195,7 @@ export class Table<TRow extends IRow> extends React.Component<ITableProps<TRow>>
                             });
                         })}
                     </TableBody>
-                    {this.props.pagingInfo && (
+                    {this.props.pagingInfo && shouldRenderBottomPagination && (
                         <TableFooter>
                             <TableRow>
                                 <TablePagination totalCount={this.props.totalCount} pagingInfo={this.props.pagingInfo} rowName={this.props.rowName} />


### PR DESCRIPTION
For tables with many pages it may come in handy to have the pagination at the top of the table too (a client of us requested it). This PR adds an optional prop `pagination` to the `Table` component, allowing the pagination to be at the top, the bottom, both or hide it completely. The component defaults to `pagination: bottom` to avoid breaking changes.