### PR TITLE
Fix PagingData interface

### DIFF
--- a/packages/react-admin-core/src/table/paging/IPagingInfo.ts
+++ b/packages/react-admin-core/src/table/paging/IPagingInfo.ts
@@ -3,7 +3,7 @@ import * as React from "react";
 export interface IPagingInfo {
     fetchNextPage?: () => void;
     fetchPreviousPage?: () => void;
-    totalPages?: number;
+    totalPages?: number | null;
     currentPage?: number;
     attachTableRef: (ref: React.RefObject<HTMLDivElement | undefined>) => void;
 }

--- a/packages/react-admin-core/src/table/paging/createPagePagingActions.ts
+++ b/packages/react-admin-core/src/table/paging/createPagePagingActions.ts
@@ -4,7 +4,7 @@ import { IPagingInfo } from "./IPagingInfo";
 interface IPagePagingData {
     nextPage: number | null;
     previousPage: number | null;
-    totalPages?: number;
+    totalPages?: number | null;
 }
 
 export function createPagePagingActions<TData extends IPagePagingData>(pagingApi: IPagingApi<number>, data: TData): IPagingInfo {

--- a/packages/react-admin-core/src/table/paging/createRestPagingActions.ts
+++ b/packages/react-admin-core/src/table/paging/createRestPagingActions.ts
@@ -10,7 +10,7 @@ function getPageParameterFromUrl(url: string, options: IOptions) {
 interface IRestPagingData {
     nextPage?: string;
     previousPage?: string;
-    totalPages?: number;
+    totalPages?: number | null;
 }
 
 interface IOptions {


### PR DESCRIPTION
Apollo Codegen generates optional types as `type | null`. When creating a paginated response with an optional `totalPages`, the generated type doesn't work with the pagination interfaces of react-admin.