### PR TITLE
Export Excel Api for Paged Api Source

### DIFF
--- a/packages/react-admin-core/src/table/ExcelExportButton.tsx
+++ b/packages/react-admin-core/src/table/ExcelExportButton.tsx
@@ -24,11 +24,21 @@ export const ExcelExportButton: React.FunctionComponent<IProps> = ({ onClick, ch
         }
     };
 
-    const { loading } = exportApi;
+    const { loading, progress } = exportApi;
 
     return (
         <Button color="default" onClick={onClickButtonPressed}>
-            {loading ? <>{loadingComponent ? loadingComponent : <CircularProgress size={23} />}</> : <FileIcon fileType={"application/msexcel"} />}
+            {loading ? (
+                <>
+                    {loadingComponent ? (
+                        loadingComponent
+                    ) : (
+                        <CircularProgress size={23} variant={progress ? "determinate" : "indeterminate"} value={progress} />
+                    )}
+                </>
+            ) : (
+                <FileIcon fileType={"application/msexcel"} />
+            )}
 
             <TextContainer>{children != null ? children : "Export"}</TextContainer>
         </Button>

--- a/packages/react-admin-core/src/table/excelexport/IExportApi.ts
+++ b/packages/react-admin-core/src/table/excelexport/IExportApi.ts
@@ -2,6 +2,7 @@ import { IRow, Table } from "../Table";
 
 export interface IExportApi<TRow extends IRow> {
     loading: boolean;
+    progress?: number;
     exportTable: () => void;
     attachTable: (ref: Table<TRow>) => void;
 }

--- a/packages/react-admin-core/src/table/excelexport/index.ts
+++ b/packages/react-admin-core/src/table/excelexport/index.ts
@@ -1,4 +1,5 @@
 export * from "./createExcelExportDownload";
 export * from "./useExportDisplayedTableData";
 export * from "./useExportTableQuery";
+export * from "./useExportPagedTableQuery";
 export * from "./IExportApi";

--- a/packages/react-admin-core/src/table/excelexport/useExportPagedTableQuery.tsx
+++ b/packages/react-admin-core/src/table/excelexport/useExportPagedTableQuery.tsx
@@ -1,0 +1,72 @@
+import { useApolloClient } from "@apollo/react-hooks";
+import * as React from "react";
+import { Table } from "../Table";
+import { ITableQueryApi } from "../TableQueryContext";
+import { createExcelExportDownload, IExcelExportOptions } from "./createExcelExportDownload";
+import { IExportApi } from "./IExportApi";
+
+interface IOptions<IVariables> {
+    variablesForPage: (page: number) => IVariables;
+    fromPage?: number;
+    toPage?: number;
+}
+
+export function useExportPagedTableQuery<IVariables>(
+    api: ITableQueryApi,
+    options: IOptions<IVariables>,
+    excelOptions?: IExcelExportOptions,
+): IExportApi<any> {
+    let tableRef: Table<any> | undefined;
+    const [progress, setProgress] = React.useState(0);
+    const [loading, setLoading] = React.useState(false);
+    function attachTable(ref: Table<any>) {
+        tableRef = ref;
+    }
+
+    const client = useApolloClient();
+
+    async function exportTable() {
+        if (tableRef != null) {
+            await setProgress(0);
+            await setLoading(true);
+
+            const { fromPage = 1, toPage = 1 } = options;
+
+            try {
+                const exportData: any[] = [];
+
+                for (let i = fromPage; i <= toPage; ++i) {
+                    const query = api.getQuery();
+                    const innerOptions = api.getInnerOptions();
+
+                    const variables = options.variablesForPage(i);
+                    const response = await client.query<any, IVariables>({
+                        query,
+                        ...innerOptions,
+                        variables: { ...variables },
+                    });
+
+                    const data = api.resolveTableData(response.data);
+
+                    if (data && data.data) {
+                        exportData.push(...data.data);
+                    }
+                    const progressInPercent = (i / (toPage - fromPage)) * 100;
+                    await setProgress(progressInPercent);
+                }
+                createExcelExportDownload<any>(tableRef.props.columns, exportData, excelOptions);
+            } catch (e) {
+                throw new Error("Error happend while exporting data");
+            } finally {
+                await setLoading(false);
+            }
+        }
+    }
+
+    return {
+        loading,
+        progress,
+        exportTable,
+        attachTable,
+    };
+}

--- a/packages/react-admin-stories/src/react-admin-core/TableExportAllPages.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/TableExportAllPages.tsx
@@ -1,0 +1,139 @@
+import { ApolloProvider } from "@apollo/react-hooks";
+import { storiesOf } from "@storybook/react";
+import {
+    createRestStartLimitPagingActions,
+    ExcelExportButton,
+    Table,
+    TableQuery,
+    useExportDisplayedTableData,
+    useExportPagedTableQuery,
+    useTableQuery,
+    useTableQueryPaging,
+} from "@vivid-planet/react-admin-core";
+import { InMemoryCache } from "apollo-cache-inmemory";
+import { ApolloClient } from "apollo-client";
+import { ApolloLink } from "apollo-link";
+import { RestLink } from "apollo-link-rest";
+import gql from "graphql-tag";
+import * as React from "react";
+
+const gqlRest = gql;
+
+const query = gqlRest`
+query users(
+    $query: String
+    $start : Int
+    $limit : Int
+) {
+    photos(
+        query: $query
+        start: $start
+        limit: $limit
+    ) @rest(type: "Photos", path: "photos?_start={args.start}&_limit={args.limit}") {
+        id
+        albumId
+        title
+        thumbnailUrl
+    }
+}
+`;
+interface IPhoto {
+    id: number;
+    albumId: number;
+    title: string;
+    thumbnailUrl: string;
+}
+
+interface IQueryData {
+    photos: IPhoto[];
+}
+
+interface IVariables {
+    start: number;
+    limit: number;
+}
+
+function Story() {
+    const totalCount = 5000;
+    const loadLimit = 50;
+    const pagingApi = useTableQueryPaging(0);
+
+    const { tableData, api, loading, error } = useTableQuery<IQueryData, IVariables>()(query, {
+        variables: {
+            start: pagingApi.current,
+            limit: loadLimit,
+        },
+        resolveTableData: data => ({
+            data: data.photos,
+            totalCount,
+            pagingInfo: createRestStartLimitPagingActions(pagingApi, {
+                totalPages: Math.ceil(totalCount / loadLimit), // Don't calculate this in a real application
+                loadLimit,
+            }),
+        }),
+    });
+
+    const exportApi = useExportPagedTableQuery<IVariables>(api, {
+        fromPage: 0,
+        toPage: totalCount / loadLimit,
+        variablesForPage: page => {
+            return {
+                start: page * loadLimit,
+                limit: loadLimit,
+            };
+        },
+    });
+
+    return (
+        <TableQuery api={api} loading={loading} error={error}>
+            {tableData && (
+                <>
+                    <ExcelExportButton exportApi={exportApi} />
+
+                    <Table
+                        exportApis={[exportApi]}
+                        {...tableData}
+                        columns={[
+                            {
+                                name: "thumbnailUrl",
+                                header: "Thumbnail",
+                                sortable: true,
+                                render: (row: IPhoto) => {
+                                    return <img src={row.thumbnailUrl} />;
+                                },
+                                headerExcel: "Thumbnail Url",
+                                renderExcel: (row: IPhoto) => {
+                                    return row.thumbnailUrl;
+                                },
+                            },
+                            {
+                                name: "title",
+                                header: "Title",
+                                sortable: true,
+                            },
+                        ]}
+                    />
+                </>
+            )}
+        </TableQuery>
+    );
+}
+
+storiesOf("react-admin-core", module)
+    .addDecorator(story => {
+        const link = ApolloLink.from([
+            new RestLink({
+                uri: "https://jsonplaceholder.typicode.com/",
+            }),
+        ]);
+
+        const cache = new InMemoryCache();
+
+        const client = new ApolloClient({
+            link,
+            cache,
+        });
+
+        return <ApolloProvider client={client}>{story()}</ApolloProvider>;
+    })
+    .add("Table Export All Pages", () => <Story />);

--- a/packages/react-admin-stories/src/react-admin-core/TableExportWithLimit.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/TableExportWithLimit.tsx
@@ -129,4 +129,4 @@ storiesOf("react-admin-core", module)
 
         return <ApolloProvider client={client}>{story()}</ApolloProvider>;
     })
-    .add("Table Export Paged", () => <Story />);
+    .add("Table Export With Limit", () => <Story />);

--- a/packages/react-admin-stories/src/react-admin-core/TableExportWithLimitFilter.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/TableExportWithLimitFilter.tsx
@@ -152,4 +152,4 @@ storiesOf("react-admin-core", module)
 
         return <ApolloProvider client={client}>{story()}</ApolloProvider>;
     })
-    .add("Table Export Paged Filter", () => <Story />);
+    .add("Table Export With Limit Filter", () => <Story />);


### PR DESCRIPTION
## New Features:
* new Hook `useExportPagedTableQuery()` which offers Api to load data for export with multiple queries
* Excel Export Button shows Progress 


## useExportPagedTableQuery()

New Hook which can be used to load paged data for export with multiple requests.

Intended to use for paged data with a huge amount of rows e.g. (e.g. > 10.000 data entries). It is better to request data with multiple requests to keep server load/ server memory low.



## Excel Export Button with Progress
![Screenshot 2019-12-16 at 09 43 59](https://user-images.githubusercontent.com/6098356/70892003-9d4a7e00-1fe8-11ea-88a1-f9c8931803f3.png)
![Screenshot 2019-12-16 at 09 43 22](https://user-images.githubusercontent.com/6098356/70892007-9facd800-1fe8-11ea-8a04-a33e6fd49deb.png)
![Screenshot 2019-12-16 at 09 43 24](https://user-images.githubusercontent.com/6098356/70892037-ad625d80-1fe8-11ea-9cdb-8f210e9d5ee6.png)
![Screenshot 2019-12-16 at 09 43 26](https://user-images.githubusercontent.com/6098356/70892016-a50a2280-1fe8-11ea-8ba6-30dbdfff5ce2.png)


## Sample Usage:

### Creating Export Api:
```
  const exportApi = useExportPagedTableQuery<IVariables>(api, {
        fromPage: 0,
        toPage: totalCount / loadLimit,
        variablesForPage: page => {
            return {
                start: page * loadLimit,
                limit: loadLimit,
            };
        },
    });
```

### Table
```
<Table
        exportApis={[exportApi]}
         ...
/>
```
