### PR TITLE
fix: exporting columns with same name, exports all column values now

### DIFF
--- a/packages/react-admin-core/src/table/excelexport/createExcelExportDownload.ts
+++ b/packages/react-admin-core/src/table/excelexport/createExcelExportDownload.ts
@@ -32,7 +32,7 @@ export async function createExcelExportDownload<TRow extends IRow>(
         if (isVisible(VisibleType.Export, column.visible)) {
             excelColumns.push({
                 header,
-                key: column.name,
+                key: column.name + columnIndex,
                 width: 20,
                 outlineLevel: 0,
                 style: {},
@@ -48,12 +48,12 @@ export async function createExcelExportDownload<TRow extends IRow>(
         data.map(row => {
             const newRow: { [key: string]: string | number | null } = {};
 
-            columns.forEach(column => {
+            columns.forEach((column, index) => {
                 if (column.renderExcel) {
-                    newRow[column.name] = column.renderExcel(row);
+                    newRow[column.name + index] = column.renderExcel(row);
                 } else {
                     const render = column.render != null ? safeStringFromReactNode(column.render(row)) : null;
-                    newRow[column.name] = render != null ? render : safeColumnGet(row, column.name);
+                    newRow[column.name + index] = render != null ? render : safeColumnGet(row, column.name);
                 }
             });
             worksheet.addRow({ ...newRow });


### PR DESCRIPTION
Exporting columns with same name results in loosing values in first column by export

## Sample:

```
<Table
  ...
  columns={[
      {
          name: "title",
          header: "Title",
          sortable: true,
      },
      {
          name: "title",
          header: "Title",
          sortable: true,
          renderExcel: row => {
              return "Test";
          },
      },
  ]}
  ...
/>
```

Before:
![Screenshot 2019-12-16 at 09 57 29](https://user-images.githubusercontent.com/6098356/70893008-80af4580-1fea-11ea-87cb-5fddae3c2a18.png)

Fix:
![Screenshot 2019-12-16 at 09 56 55](https://user-images.githubusercontent.com/6098356/70893038-8c9b0780-1fea-11ea-9842-da34d38b2a3f.png)

