### PR TITLE
Remove vplint linter

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,8 +1,7 @@
 {
     "linters": {
         "*.{ts,tsx,js,jsx,json,css,scss,md}": ["prettylint"],
-        "*.{ts,tsx}": ["tslint", "lerna --loglevel silent run --stream tsc -- --silent"],
-        "*": "vplint"
+        "*.{ts,tsx}": ["tslint", "lerna --loglevel silent run --stream tsc -- --silent"]
     },
     "ignore": ["package-lock.json", "*.lock"]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
     - "8"
 cache: yarn
 before_install:
-    - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
     - curl -o- -L https://yarnpkg.com/install.sh | bash
     - export PATH="$HOME/.yarn/bin:$PATH"
 before_script:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
         "@types/recompose": "^0.30.6",
         "@types/styled-components": "4.1.8",
         "@types/uuid": "^3.4.4",
-        "@vivid-planet/vplint": "^1.0.2",
         "apollo-client": "^2.6.3",
         "date-fns": "^2.9.0",
         "exceljs": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3237,11 +3237,6 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vivid-planet/vplint@^1.0.2":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@vivid-planet/vplint/-/vplint-1.0.6.tgz#b30dcfca5df3f4a51c74d02a523a2b6fa49e3f4a"
-  integrity sha512-YFTwhVNK7FCOmuZBI8X6TsSo1IM7JssaEEp3zpddE4bUFuCkrIkbMQoKIYuySNVPu6jlHZwiWfPS/i1gCsmqyQ==
-
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"


### PR DESCRIPTION
That is the only private package not providing really additional useful linting. Removing it simplifies the workflow
as we don't need NPM_TOKEN everywhere