### PR TITLE
Prevent inconsistent height of menu-items

### DIFF
--- a/packages/react-admin-mui/src/menu/Menu.sc.tsx
+++ b/packages/react-admin-mui/src/menu/Menu.sc.tsx
@@ -1,5 +1,11 @@
+import * as React from "react";
 import { styled } from "../styled-components";
 
-export const MenuItemsWrapper = styled.div`
+interface IMenuItemsWrapperProps {
+    width: React.CSSProperties["width"];
+}
+
+export const MenuItemsWrapper = styled.div<IMenuItemsWrapperProps>`
+    width: ${({ width }) => width};
     margin-top: 20px;
 `;

--- a/packages/react-admin-mui/src/menu/Menu.tsx
+++ b/packages/react-admin-mui/src/menu/Menu.tsx
@@ -8,8 +8,9 @@ interface IProps {
     children: React.ReactNode;
 }
 
-const Menu = ({ classes, children }: WithStyles<typeof styles, true> & IProps) => {
+const Menu = ({ classes, children, theme }: WithStyles<typeof styles, true> & IProps) => {
     const { open } = React.useContext(MenuContext);
+    const themeStyles = styles(theme);
 
     return (
         <Drawer
@@ -20,7 +21,7 @@ const Menu = ({ classes, children }: WithStyles<typeof styles, true> & IProps) =
             }}
             open={open}
         >
-            <sc.MenuItemsWrapper>
+            <sc.MenuItemsWrapper width={`${(themeStyles.drawer as { width: number }).width}px`}>
                 <div className={classes.toolbar} />
                 {children}
             </sc.MenuItemsWrapper>


### PR DESCRIPTION
Make sure the width of the menu-items is always the width of the opened menu.  
This prevents the text inside the menu-item from breaking into the next line and therefore increasing it's height.