### PR TITLE
Fix persisted state for table query hooks

### DIFF
--- a/packages/react-admin-core/src/table/useTableQueryFilter.tsx
+++ b/packages/react-admin-core/src/table/useTableQueryFilter.tsx
@@ -16,7 +16,9 @@ export function useTableQueryFilter<FilterValues extends AnyObject>(
         persistedStateId?: string;
     } = {},
 ): IFilterApi<FilterValues> {
-    const [filters, setFilters] = usePersistedState<FilterValues>(defaultValues, { persistedStateId: options.persistedStateId + "_filter" });
+    const [filters, setFilters] = usePersistedState<FilterValues>(defaultValues, {
+        persistedStateId: options.persistedStateId ? options.persistedStateId + "_filter" : undefined,
+    });
     const ref = React.useRef<FormApi<FilterValues>>();
     if (!ref.current) {
         ref.current = createForm({

--- a/packages/react-admin-core/src/table/useTableQueryPaging.tsx
+++ b/packages/react-admin-core/src/table/useTableQueryPaging.tsx
@@ -14,8 +14,12 @@ export function useTableQueryPaging<T>(
         persistedStateId?: string;
     } = {},
 ): IPagingApi<T> {
-    const [page, setPage] = usePersistedState(1, { persistedStateId: options.persistedStateId + "_pagingPage" });
-    const [variables, setVariables] = usePersistedState<T>(init, { persistedStateId: options.persistedStateId + "_pagingVariables" });
+    const [page, setPage] = usePersistedState(1, {
+        persistedStateId: options.persistedStateId ? options.persistedStateId + "_pagingPage" : undefined,
+    });
+    const [variables, setVariables] = usePersistedState<T>(init, {
+        persistedStateId: options.persistedStateId ? options.persistedStateId + "_pagingVariables" : undefined,
+    });
 
     let tableRef: React.RefObject<HTMLDivElement | undefined> | undefined;
     function attachTableRef(ref: any) {

--- a/packages/react-admin-core/src/table/useTableQuerySort.tsx
+++ b/packages/react-admin-core/src/table/useTableQuerySort.tsx
@@ -19,7 +19,9 @@ export function useTableQuerySort(
         persistedStateId?: string;
     } = {},
 ): ISortApi {
-    const [sort, setSort] = usePersistedState<ISortInformation>(defaultSort, { persistedStateId: options.persistedStateId + "_sort" });
+    const [sort, setSort] = usePersistedState<ISortInformation>(defaultSort, {
+        persistedStateId: options.persistedStateId ? options.persistedStateId + "_sort" : undefined,
+    });
 
     function changeSort(columnName: string) {
         let direction = SortDirection.ASC;


### PR DESCRIPTION
`persistedStateId` should only be set if the option is set.