### PR TITLE
Add icons to buttons using the existing prop

### DIFF
--- a/packages/react-admin-core/src/FinalForm.sc.ts
+++ b/packages/react-admin-core/src/FinalForm.sc.ts
@@ -4,10 +4,4 @@ export const InnerForm = styled.div`
     margin-bottom: 20px;
 `;
 
-export const ButtonIconWrapper = styled.div`
-    margin-right: 5px;
-    font-size: 20px;
-    line-height: 28px;
-`;
-
 export const ButtonsContainer = styled.div``;

--- a/packages/react-admin-core/src/FinalForm.tsx
+++ b/packages/react-admin-core/src/FinalForm.tsx
@@ -2,8 +2,7 @@ import { useApolloClient } from "@apollo/react-hooks";
 import { CircularProgress } from "@material-ui/core";
 import Button from "@material-ui/core/Button";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
-import CancelIcon from "@material-ui/icons/Cancel";
-import SaveIcon from "@material-ui/icons/Save";
+import { Cancel as CancelIcon, Save as SaveIcon } from "@material-ui/icons";
 import { FORM_ERROR, FormApi, SubmissionErrors } from "final-form";
 import * as React from "react";
 import { AnyObject, Form, FormProps, FormRenderProps } from "react-final-form";
@@ -103,23 +102,24 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
                             <>
                                 <ButtonsContainer>
                                     {stackApi && (
-                                        <Button className={classes.saveButton} variant="text" color="default" onClick={handleCancelClick}>
-                                            <sc.ButtonIconWrapper>
-                                                <CancelIcon fontSize={"inherit"} />
-                                            </sc.ButtonIconWrapper>
+                                        <Button
+                                            className={classes.saveButton}
+                                            startIcon={<CancelIcon />}
+                                            variant="text"
+                                            color="default"
+                                            onClick={handleCancelClick}
+                                        >
                                             Abbrechen
                                         </Button>
                                     )}
                                     <Button
                                         className={classes.saveButton}
+                                        startIcon={<SaveIcon />}
                                         variant="contained"
                                         color="primary"
                                         type="submit"
                                         disabled={formRenderProps.pristine || formRenderProps.hasValidationErrors || formRenderProps.submitting}
                                     >
-                                        <sc.ButtonIconWrapper>
-                                            <SaveIcon fontSize={"inherit"} />
-                                        </sc.ButtonIconWrapper>
                                         Speichern
                                     </Button>
                                 </ButtonsContainer>

--- a/packages/react-admin-core/src/table/AddButton.tsx
+++ b/packages/react-admin-core/src/table/AddButton.tsx
@@ -10,9 +10,8 @@ interface IProps {
 export class TableAddButton extends React.Component<IProps> {
     public render() {
         return (
-            <Button color="default" onClick={this.handleAddClick}>
+            <Button color="default" onClick={this.handleAddClick} startIcon={<AddIcon />}>
                 Hinzufügen
-                <AddIcon />
             </Button>
         );
     }

--- a/packages/react-admin-core/src/table/DeleteButton.tsx
+++ b/packages/react-admin-core/src/table/DeleteButton.tsx
@@ -1,6 +1,6 @@
 import Button from "@material-ui/core/Button";
 import CircularProgress from "@material-ui/core/CircularProgress";
-import RemoveIcon from "@material-ui/icons/Remove";
+import DeleteIcon from "@material-ui/icons/Delete";
 import * as React from "react";
 import { DeleteMutation } from "../DeleteMutation";
 
@@ -17,9 +17,13 @@ export class TableDeleteButton extends React.Component<IProps> {
                     <>
                         {loading && <CircularProgress />}
                         {!loading && (
-                            <Button color="default" disabled={!this.props.selectedId} onClick={this.handleDeleteClick.bind(this, deleteBrand)}>
+                            <Button
+                                color="default"
+                                disabled={!this.props.selectedId}
+                                onClick={this.handleDeleteClick.bind(this, deleteBrand)}
+                                startIcon={<DeleteIcon />}
+                            >
                                 Löschen
-                                <RemoveIcon />
                             </Button>
                         )}
                     </>

--- a/packages/react-admin-core/src/table/ExcelExportButton.tsx
+++ b/packages/react-admin-core/src/table/ExcelExportButton.tsx
@@ -1,8 +1,6 @@
-import { CircularProgress } from "@material-ui/core";
-import Button from "@material-ui/core/Button";
+import { Button, CircularProgress, Typography } from "@material-ui/core";
 import { FileIcon } from "@vivid-planet/file-icons";
 import * as React from "react";
-import styled from "styled-components";
 import { IExportApi } from "./excelexport/IExportApi";
 
 interface IProps {
@@ -10,10 +8,6 @@ interface IProps {
     onClick?: () => void;
     loadingComponent?: React.ReactNode;
 }
-
-const TextContainer = styled.div`
-    margin-left: 8px;
-`;
 
 export const ExcelExportButton: React.FunctionComponent<IProps> = ({ onClick, children, exportApi, loadingComponent }) => {
     const onClickButtonPressed = () => {
@@ -27,20 +21,24 @@ export const ExcelExportButton: React.FunctionComponent<IProps> = ({ onClick, ch
     const { loading, progress } = exportApi;
 
     return (
-        <Button color="default" onClick={onClickButtonPressed}>
-            {loading ? (
-                <>
-                    {loadingComponent ? (
-                        loadingComponent
-                    ) : (
-                        <CircularProgress size={23} variant={progress ? "determinate" : "indeterminate"} value={progress} />
-                    )}
-                </>
-            ) : (
-                <FileIcon fileType={"application/msexcel"} />
-            )}
-
-            <TextContainer>{children != null ? children : "Export"}</TextContainer>
+        <Button
+            color="default"
+            onClick={onClickButtonPressed}
+            startIcon={
+                loading ? (
+                    <>
+                        {loadingComponent ? (
+                            loadingComponent
+                        ) : (
+                            <CircularProgress size={23} variant={progress ? "determinate" : "indeterminate"} value={progress} />
+                        )}
+                    </>
+                ) : (
+                    <FileIcon fileType={"application/msexcel"} />
+                )
+            }
+        >
+            <Typography>{children != null ? children : "Export"}</Typography>
         </Button>
     );
 };

--- a/packages/react-admin-core/src/table/LocalChangesToolbar.tsx
+++ b/packages/react-admin-core/src/table/LocalChangesToolbar.tsx
@@ -18,9 +18,8 @@ export class TableLocalChangesToolbar extends React.Component<IProps> {
                 {this.props.loading && <CircularProgress />}
                 {!this.props.loading && (
                     <Toolbar>
-                        <Button color="default" onClick={this.handleSaveClick}>
+                        <Button color="default" onClick={this.handleSaveClick} startIcon={<SaveIcon />}>
                             Speichern
-                            <SaveIcon />
                         </Button>
                         {this.props.localChangesCount} unsaved change(s)
                     </Toolbar>

--- a/packages/react-admin-core/src/table/TableFilterFinalForm.sc.ts
+++ b/packages/react-admin-core/src/table/TableFilterFinalForm.sc.ts
@@ -3,8 +3,3 @@ import styled from "styled-components";
 export const FormHeader = styled.div`
     margin-bottom: 20px;
 `;
-
-export const FilterCancelIconWrapper = styled.div`
-    margin-right: 5px;
-    font-size: 0;
-`;

--- a/packages/react-admin-core/src/table/TableFilterFinalForm.tsx
+++ b/packages/react-admin-core/src/table/TableFilterFinalForm.tsx
@@ -55,13 +55,11 @@ export class TableFilterFinalForm<FilterValues = AnyObject> extends React.Compon
                                     <Button
                                         variant="text"
                                         color="default"
+                                        startIcon={<CancelIcon />}
                                         onClick={() => {
                                             formRenderProps.form.reset();
                                         }}
                                     >
-                                        <sc.FilterCancelIconWrapper>
-                                            <CancelIcon fontSize={"small"} />
-                                        </sc.FilterCancelIconWrapper>
                                         Filter zurücksetzen
                                     </Button>
                                 </Grid>

--- a/packages/react-admin-mui/src/menu/Item.tsx
+++ b/packages/react-admin-mui/src/menu/Item.tsx
@@ -1,5 +1,3 @@
-import { Button } from "@material-ui/core";
-import { ButtonProps } from "@material-ui/core/Button";
 import { ListItemProps } from "@material-ui/core/ListItem";
 import * as React from "react";
 import { IMenuLevel, MenuContext } from "./index";


### PR DESCRIPTION
Using the `startIcon` and `endIcon` props makes sure, spacing between
the icon and the text is consistent across all buttons, making any
wrappers with margin for spacing redundant.