### PR TITLE
Keep Circle Spinner always in viewport

### DIFF
--- a/packages/react-admin-core/src/table/TableQuery.sc.ts
+++ b/packages/react-admin-core/src/table/TableQuery.sc.ts
@@ -2,8 +2,14 @@ import styled from "styled-components";
 
 export const ProgressOverlayContainer = styled.div`
     position: relative;
-    min-height: 500px;
     z-index: 1;
+`;
+
+export const ProgressOverlayInnerContainer = styled.div`
+    transform: translate(50%, 200px);
+    position: sticky;
+    width: 100%;
+    top: 0;
 `;
 
 export const TableCircularProgressContainer = styled.div`
@@ -18,8 +24,6 @@ export const TableCircularProgressContainer = styled.div`
     height: 100px;
     width: 100px;
     display: flex;
-    left: 50%;
-    top: 50%;
 `;
 
 export const ProgressContainer = styled.div`

--- a/packages/react-admin-core/src/table/TableQuery.tsx
+++ b/packages/react-admin-core/src/table/TableQuery.tsx
@@ -26,11 +26,13 @@ export function TableQuery(props: IProps) {
             }}
         >
             <sc.ProgressOverlayContainer>
-                {props.loading && (
-                    <sc.TableCircularProgressContainer>
-                        <CircularProgress />
-                    </sc.TableCircularProgressContainer>
-                )}
+                <sc.ProgressOverlayInnerContainer>
+                    {props.loading && (
+                        <sc.TableCircularProgressContainer>
+                            <CircularProgress />
+                        </sc.TableCircularProgressContainer>
+                    )}
+                </sc.ProgressOverlayInnerContainer>
                 {props.error && <p>Error :( {props.error.toString()}</p>}
                 {props.children}
             </sc.ProgressOverlayContainer>


### PR DESCRIPTION
fixed circle spinner position problem if table is higher than the viewport - loading spinner is now always visible in viewport