### PR TITLE
Allow permanent and temporary menu

### DIFF
--- a/packages/react-admin-mui/src/menu/Menu.tsx
+++ b/packages/react-admin-mui/src/menu/Menu.tsx
@@ -2,18 +2,24 @@ import { Drawer, Theme } from "@material-ui/core";
 import { createStyles, WithStyles, withStyles } from "@material-ui/styles";
 import * as React from "react";
 import { useHistory } from "react-router";
+import { ThemeContext } from "styled-components";
 import { MenuContext } from "./Context";
 import * as sc from "./Menu.sc";
+import useWindowSize from "./useWindowSize";
 
 interface IProps {
     children: React.ReactNode;
-    variant?: "permanent" | "temporary";
+    permanentMenuMinWidth?: number;
 }
 
-const Menu = ({ classes, children, variant = "permanent", theme }: WithStyles<typeof styles, true> & IProps) => {
+const Menu = ({ classes, children, permanentMenuMinWidth: passedPermanentMenuMinWidth, theme }: WithStyles<typeof styles, true> & IProps) => {
     const { open, toggleOpen } = React.useContext(MenuContext);
-    const themeStyles = styles(theme);
+    const themeContext = React.useContext(ThemeContext);
     const history = useHistory();
+    const windowSize = useWindowSize();
+    const themeStyles = styles(theme);
+    const permanentMenuMinWidth = passedPermanentMenuMinWidth ? passedPermanentMenuMinWidth : themeContext.breakpoints.values.lg;
+    const variant = windowSize.width < permanentMenuMinWidth ? "temporary" : "permanent";
 
     React.useEffect(() => {
         if (variant === "temporary" && open) {

--- a/packages/react-admin-mui/src/menu/Menu.tsx
+++ b/packages/react-admin-mui/src/menu/Menu.tsx
@@ -1,28 +1,52 @@
 import { Drawer, Theme } from "@material-ui/core";
 import { createStyles, WithStyles, withStyles } from "@material-ui/styles";
 import * as React from "react";
+import { useHistory } from "react-router";
 import { MenuContext } from "./Context";
 import * as sc from "./Menu.sc";
 
 interface IProps {
     children: React.ReactNode;
+    variant?: "permanent" | "temporary";
 }
 
-const Menu = ({ classes, children, theme }: WithStyles<typeof styles, true> & IProps) => {
-    const { open } = React.useContext(MenuContext);
+const Menu = ({ classes, children, variant = "permanent", theme }: WithStyles<typeof styles, true> & IProps) => {
+    const { open, toggleOpen } = React.useContext(MenuContext);
     const themeStyles = styles(theme);
+    const history = useHistory();
+
+    React.useEffect(() => {
+        if (variant === "temporary" && open) {
+            toggleOpen();
+        }
+    }, []);
+
+    React.useEffect(() => {
+        return history.listen(() => {
+            if (variant === "temporary" && open) {
+                toggleOpen();
+            }
+        });
+    }, [history, variant, open]);
+
+    const getVariantDependantDrawerProps = () => {
+        if (variant === "temporary") {
+            return {
+                onBackdropClick: toggleOpen,
+            };
+        }
+        return {};
+    };
+
+    let menuClasses: string = classes.drawer;
+    if (variant === "permanent") {
+        menuClasses += " " + (open ? classes.permanentDrawerOpen : classes.permanentDrawerClose);
+    }
 
     return (
-        <Drawer
-            variant="permanent"
-            className={classes.drawer + " " + (open ? classes.drawerOpen : classes.drawerClose)}
-            classes={{
-                paper: classes.drawer + " " + (open ? classes.drawerOpen : classes.drawerClose),
-            }}
-            open={open}
-        >
+        <Drawer variant={variant} className={menuClasses} classes={{ paper: menuClasses }} open={open} {...getVariantDependantDrawerProps()}>
             <sc.MenuItemsWrapper width={`${(themeStyles.drawer as { width: number }).width}px`}>
-                <div className={classes.toolbar} />
+                {variant === "permanent" && <div className={classes.toolbar} />}
                 {children}
             </sc.MenuItemsWrapper>
         </Drawer>
@@ -34,19 +58,19 @@ const styles = (theme: Theme) => {
         drawer: {
             width: 300, //  theme.appDrawer.width,
         },
-        drawerOpen: {
+        permanentDrawerOpen: {
             transition: theme.transitions.create("width", {
                 easing: theme.transitions.easing.sharp,
                 duration: theme.transitions.duration.enteringScreen,
             }),
         },
-        drawerClose: {
+        permanentDrawerClose: {
             transition: theme.transitions.create("width", {
                 easing: theme.transitions.easing.sharp,
                 duration: theme.transitions.duration.leavingScreen,
             }),
             overflowX: "hidden",
-            width: 60,
+            width: 0,
         },
         toolbar: theme.mixins.toolbar,
     });

--- a/packages/react-admin-mui/src/menu/useWindowSize.tsx
+++ b/packages/react-admin-mui/src/menu/useWindowSize.tsx
@@ -11,7 +11,7 @@ export default function useWindowSize(): IWindowSize {
         height: window.innerHeight,
     });
 
-    const [windowSize, setWindowSize] = React.useState(getSize);
+    const [windowSize, setWindowSize] = React.useState<IWindowSize>(getSize());
 
     React.useEffect(() => {
         const handleResize = () => {

--- a/packages/react-admin-mui/src/menu/useWindowSize.tsx
+++ b/packages/react-admin-mui/src/menu/useWindowSize.tsx
@@ -1,7 +1,12 @@
 import * as React from "react";
 
-export const useWindowSize = () => {
-    const getSize = () => ({
+interface IWindowSize {
+    width: number;
+    height: number;
+}
+
+export default function useWindowSize(): IWindowSize {
+    const getSize = (): IWindowSize => ({
         width: window.innerWidth,
         height: window.innerHeight,
     });
@@ -20,4 +25,4 @@ export const useWindowSize = () => {
     }, []);
 
     return windowSize;
-};
+}

--- a/packages/react-admin-stories/src/react-admin-mui/Menu.tsx
+++ b/packages/react-admin-stories/src/react-admin-mui/Menu.tsx
@@ -5,10 +5,16 @@ import { MasterLayout, Menu, MenuCollapsibleItem, MenuItemRouterLink } from "@vi
 import * as React from "react";
 import { Route, Switch } from "react-router";
 import StoryRouter from "storybook-react-router";
+import { ThemeContext } from "styled-components";
+import { useWindowSize } from "./hooks";
 
 function AppMenu() {
+    const windowSize = useWindowSize();
+    const themeContext = React.useContext(ThemeContext);
+    const showTemporaryMenu = windowSize.width < themeContext.breakpoints.values.lg;
+
     return (
-        <Menu>
+        <Menu variant={showTemporaryMenu ? "temporary" : "permanent"}>
             <MenuItemRouterLink text="Foo1" icon={<CalendarToday />} to="/foo1" />
             <MenuItemRouterLink text="Foo2" icon={<School />} to="/foo2" />
             <MenuCollapsibleItem text="Foo3" icon={<Settings />} collapsible={true} isOpen={false}>

--- a/packages/react-admin-stories/src/react-admin-mui/Menu.tsx
+++ b/packages/react-admin-stories/src/react-admin-mui/Menu.tsx
@@ -5,46 +5,34 @@ import { MasterLayout, Menu, MenuCollapsibleItem, MenuItemRouterLink } from "@vi
 import * as React from "react";
 import { Route, Switch } from "react-router";
 import StoryRouter from "storybook-react-router";
-import { ThemeContext } from "styled-components";
-import { useWindowSize } from "./hooks";
 
-function AppMenu() {
-    const windowSize = useWindowSize();
-    const themeContext = React.useContext(ThemeContext);
-    const showTemporaryMenu = windowSize.width < themeContext.breakpoints.values.lg;
+const AppMenu: React.FC = () => (
+    <Menu>
+        <MenuItemRouterLink text="Foo1" icon={<CalendarToday />} to="/foo1" />
+        <MenuItemRouterLink text="Foo2" icon={<School />} to="/foo2" />
+        <MenuCollapsibleItem text="Foo3" icon={<Settings />} collapsible={true} isOpen={false}>
+            <MenuItemRouterLink text="Foo4" icon={<Home />} to="/foo4" />
+            <MenuItemRouterLink text="Foo5" icon={<Home />} to="/foo5" />
+        </MenuCollapsibleItem>
+    </Menu>
+);
 
-    return (
-        <Menu variant={showTemporaryMenu ? "temporary" : "permanent"}>
-            <MenuItemRouterLink text="Foo1" icon={<CalendarToday />} to="/foo1" />
-            <MenuItemRouterLink text="Foo2" icon={<School />} to="/foo2" />
-            <MenuCollapsibleItem text="Foo3" icon={<Settings />} collapsible={true} isOpen={false}>
-                <MenuItemRouterLink text="Foo4" icon={<Home />} to="/foo4" />
-                <MenuItemRouterLink text="Foo5" icon={<Home />} to="/foo5" />
-            </MenuCollapsibleItem>
-        </Menu>
-    );
-}
+const AppHeader: React.FC = () => (
+    <Typography variant="h5" color="primary">
+        Example
+    </Typography>
+);
 
-function AppHeader() {
-    return (
-        <Typography variant="h5" color="primary">
-            Example
-        </Typography>
-    );
-}
-
-function Story() {
-    return (
-        <MasterLayout headerComponent={AppHeader} menuComponent={AppMenu}>
-            <Switch>
-                <Route path="/foo1" render={() => <div>Foo 1</div>} />
-                <Route path="/foo2" render={() => <div>Foo 2</div>} />
-                <Route path="/foo4" render={() => <div>Foo 4</div>} />
-                <Route path="/foo5" render={() => <div>Foo 5</div>} />
-            </Switch>
-        </MasterLayout>
-    );
-}
+const Story: React.FC = () => (
+    <MasterLayout headerComponent={AppHeader} menuComponent={AppMenu}>
+        <Switch>
+            <Route path="/foo1" render={() => <div>Foo 1</div>} />
+            <Route path="/foo2" render={() => <div>Foo 2</div>} />
+            <Route path="/foo4" render={() => <div>Foo 4</div>} />
+            <Route path="/foo5" render={() => <div>Foo 5</div>} />
+        </Switch>
+    </MasterLayout>
+);
 
 storiesOf("react-admin-mui", module)
     .addDecorator(StoryRouter())

--- a/packages/react-admin-stories/src/react-admin-mui/hooks.tsx
+++ b/packages/react-admin-stories/src/react-admin-mui/hooks.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+export const useWindowSize = () => {
+    const getSize = () => ({
+        width: window.innerWidth,
+        height: window.innerHeight,
+    });
+
+    const [windowSize, setWindowSize] = React.useState(getSize);
+
+    React.useEffect(() => {
+        const handleResize = () => {
+            setWindowSize(getSize());
+        };
+
+        window.addEventListener("resize", handleResize);
+        return () => {
+            window.removeEventListener("resize", handleResize);
+        };
+    }, []);
+
+    return windowSize;
+};


### PR DESCRIPTION
The menu state where only the icons of the menu are shown is not required.

The function `getVariantDependantDrawerProps` is needed because setting
the prop `onBackdropClick` to a drawer with variant of "permanent"
(even if the value is `undefined`) causes an error.