### PR TITLE
Remove z-index from TableQuery container

### DIFF
--- a/packages/react-admin-core/src/table/TableQuery.sc.ts
+++ b/packages/react-admin-core/src/table/TableQuery.sc.ts
@@ -2,7 +2,6 @@ import styled from "styled-components";
 
 export const ProgressOverlayContainer = styled.div`
     position: relative;
-    z-index: 1;
 `;
 
 export const ProgressOverlayInnerContainer = styled.div`


### PR DESCRIPTION
This `z-index` doesn't do anything and causes a lot of headache in combination with dropdown selects.