### PR TITLE
Fix internalisation of month and weekdays in DatePicker and DateRangePicker

### DIFF
--- a/packages/react-admin-date-picker/src/DatePicker.tsx
+++ b/packages/react-admin-date-picker/src/DatePicker.tsx
@@ -13,8 +13,12 @@ interface IProps extends FieldRenderProps<string | Date, HTMLInputElement> {
 export const DatePicker: React.FC<IProps> = ({ input: { value, onChange, ...restInput }, meta, fullWidth = false, color = "default", ...props }) => {
     const localeName = useLocaleName();
     const locale = moment().locale(localeName);
-    const [focused, setFocus] = React.useState();
+    const [focused, setFocus] = React.useState(false);
     const selectedDate = value ? moment(value) : null;
+
+    React.useEffect(() => {
+        moment.locale(localeName);
+    }, [localeName]);
 
     return (
         <sc.SingleDatePickerWrapper fullWidth={fullWidth} color={color}>

--- a/packages/react-admin-date-picker/src/DateRangePicker.tsx
+++ b/packages/react-admin-date-picker/src/DateRangePicker.tsx
@@ -22,6 +22,10 @@ export const DateRangePicker: React.FC<IProps> = ({ input: { value, onChange }, 
     const start = value.start ? moment(value.start) : null;
     const end = value.end ? moment(value.end) : null;
 
+    React.useEffect(() => {
+        moment.locale(localeName);
+    }, [localeName]);
+
     return (
         <sc.DateRangePickerWrapper fullWidth={fullWidth} color={color}>
             <AirBNBDateRangePicker


### PR DESCRIPTION
Im Kalender werden die Monats- und Wochentagsnamen nicht in der richtigen Sprache angezeigt.