### PR TITLE
Add RteReadOnly component

### DIFF
--- a/packages/react-admin-rte/src/core/Rte.tsx
+++ b/packages/react-admin-rte/src/core/Rte.tsx
@@ -63,6 +63,18 @@ const defaultOptions: IRteOptions = {
 export interface IRteRef {
     focus: () => void;
 }
+
+export const styleMap = {
+    SUP: {
+        verticalAlign: "super",
+        fontSize: "smaller",
+    },
+    SUB: {
+        verticalAlign: "sub",
+        fontSize: "smaller",
+    },
+};
+
 const Rte: React.RefForwardingComponent<any, IProps> = (props, ref) => {
     const { value: editorState, onChange, options: passedOptions } = props;
     const editorRef = React.useRef<DraftJsEditor>(null);
@@ -108,17 +120,6 @@ const Rte: React.RefForwardingComponent<any, IProps> = (props, ref) => {
             onChange(newEditorState);
         }
     }
-
-    const styleMap = {
-        SUP: {
-            verticalAlign: "super",
-            fontSize: "smaller",
-        },
-        SUB: {
-            verticalAlign: "sub",
-            fontSize: "smaller",
-        },
-    };
 
     return (
         <sc.Root ref={editorWrapperRef}>

--- a/packages/react-admin-rte/src/core/RteReadOnly.tsx
+++ b/packages/react-admin-rte/src/core/RteReadOnly.tsx
@@ -1,0 +1,51 @@
+import "draft-js/dist/Draft.css"; // important for nesting of ul/ol
+
+import { Editor as DraftJsEditor, EditorState } from "draft-js";
+import * as React from "react";
+import { ICustomBlockTypeMap } from "./types";
+import createBlockRenderMap from "./utils/createBlockRenderMap";
+import { styleMap } from "./Rte";
+
+export interface IRteReadOnlyOptions {
+    customBlockMap?: ICustomBlockTypeMap;
+}
+
+export type IOptions = Partial<IRteReadOnlyOptions>;
+
+export interface IProps {
+    value: EditorState;
+    plainTextOnly?: boolean;
+    options?: IOptions;
+}
+
+const defaultOptions: IRteReadOnlyOptions = {};
+
+const RteReadOnly: React.FC<IProps> = ({ value: editorState, options: passedOptions, plainTextOnly }) => {
+    const editorRef = React.useRef<DraftJsEditor>(null);
+    const options = passedOptions ? { ...defaultOptions, ...passedOptions } : defaultOptions; // merge default options with passed options
+    const blockRenderMap = createBlockRenderMap({ customBlockTypeMap: options.customBlockMap });
+
+    function handleOnChange() {
+        editorRef.current && editorRef.current.blur();
+    }
+
+    if (plainTextOnly) {
+        return <>{editorState.getCurrentContent().getPlainText()}</>;
+    }
+
+    return (
+        <>
+            <DraftJsEditor
+                ref={editorRef}
+                editorState={editorState}
+                onChange={handleOnChange}
+                spellCheck={false}
+                customStyleMap={styleMap}
+                readOnly={true}
+                blockRenderMap={blockRenderMap}
+            />
+        </>
+    );
+};
+
+export default RteReadOnly;

--- a/packages/react-admin-rte/src/field/createRteField.tsx
+++ b/packages/react-admin-rte/src/field/createRteField.tsx
@@ -4,6 +4,7 @@ import { FieldRenderProps } from "react-final-form";
 
 import makeRteApi, { IMakeRteApiProps, OnDebouncedContentChangeFn } from "../core/makeRteApi";
 import Rte, { IOptions as RteOptions, IProps as RteProps } from "../core/Rte";
+import RteReadOnlyBase from "../core/RteReadOnly";
 
 interface IConfig<T = any> {
     rteApiOptions?: IMakeRteApiProps<T>;
@@ -14,11 +15,12 @@ const defaultConfig: IConfig = {};
 
 function createRteField<T = any>(config: IConfig<T> = defaultConfig) {
     const { rteApiOptions, rteOptions } = config;
-    const [useRteApi] = makeRteApi(rteApiOptions);
+    const [useRteApi, { createStateFromRawContent }] = makeRteApi(rteApiOptions);
 
     const RteField: React.FunctionComponent<FieldRenderProps<T, HTMLInputElement> & Pick<RteProps, "options">> = ({
         input: { value, onChange, ...restInput },
         meta,
+        value: remove,
         ...rest
     }) => {
         const ref = React.useRef<any>();
@@ -46,7 +48,22 @@ function createRteField<T = any>(config: IConfig<T> = defaultConfig) {
         );
     };
 
-    return { RteField };
+    const RteReadOnly: React.FunctionComponent<{ content?: T; plainTextOnly?: boolean }> = ({ content, plainTextOnly }) => {
+        if (!content) {
+            return null;
+        }
+        return (
+            <RteReadOnlyBase
+                value={createStateFromRawContent(content)}
+                plainTextOnly={plainTextOnly}
+                options={{
+                    customBlockMap: rteOptions ? rteOptions.customBlockMap : undefined,
+                }}
+            />
+        );
+    };
+
+    return { RteField, RteReadOnly };
 }
 
 export default createRteField;

--- a/packages/react-admin-rte/src/index.ts
+++ b/packages/react-admin-rte/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Rte, IRteRef, IOptions as IRteOptions, IProps as IRteProps } from "./core/Rte";
+export { default as RteReadOnly, IOptions as IRteReadOnlyOptions, IProps as IRteReadOnlyProps } from "./core/RteReadOnly";
 export { default as makeRteApi, IMakeRteApiProps, OnDebouncedContentChangeFn, IRteApiProps } from "./core/makeRteApi";
 export { default as createRteField } from "./field/createRteField";
 

--- a/packages/react-admin-stories/src/react-admin-rte/Field.tsx
+++ b/packages/react-admin-stories/src/react-admin-rte/Field.tsx
@@ -4,30 +4,35 @@ import { Field } from "@vivid-planet/react-admin-form";
 import { createRteField } from "@vivid-planet/react-admin-rte";
 import * as React from "react";
 import { Form } from "react-final-form";
-import { PrintAnything } from "./helper";
+import { Typography } from "@material-ui/core";
 
-const { RteField } = createRteField();
+const { RteField, RteReadOnly } = createRteField();
 
 function Story() {
-    const [submitedValue, setSubmittedValue] = React.useState<any>();
+    const [submitedValue, setSubmittedValue] = React.useState<{ rteContent: any }>({ rteContent: undefined });
 
     return (
-        <div style={{ width: "300px" }}>
-            <Form
-                onSubmit={values => {
-                    //
-                    setSubmittedValue(values);
-                }}
-                render={({ handleSubmit }) => (
-                    <form onSubmit={handleSubmit}>
-                        <Field name="rteContent" label="Rich Text" component={RteField} />
-                        <Button type="submit" component={"button"} disableTouchRipple>
-                            Submit
-                        </Button>
-                    </form>
-                )}
-            />
-            <PrintAnything label="This has been submitted">{submitedValue}</PrintAnything>
+        <div>
+            <div style={{ maxWidth: "800px" }}>
+                <Form
+                    onSubmit={values => {
+                        //
+                        setSubmittedValue(values);
+                    }}
+                    render={({ handleSubmit }) => (
+                        <form onSubmit={handleSubmit}>
+                            <Field name="rteContent" label="Rich Text" component={RteField} />
+                            <Button color="primary" variant="contained" type="submit" component={"button"} disableTouchRipple>
+                                Submit
+                            </Button>
+                        </form>
+                    )}
+                />
+            </div>
+            <Typography variant="h5" color="primary">
+                Readonly Component:
+            </Typography>
+            <RteReadOnly content={submitedValue.rteContent} />
         </div>
     );
 }

--- a/packages/react-admin-stories/src/react-admin-rte/FieldAllOptions.tsx
+++ b/packages/react-admin-stories/src/react-admin-rte/FieldAllOptions.tsx
@@ -6,35 +6,41 @@ import * as React from "react";
 import { Form } from "react-final-form";
 import { PrintAnything } from "./helper";
 import { ContentFormat, defaultContent, makeApiOptions, rteOptions } from "./RteAllOptions";
+import { Typography } from "@material-ui/core";
 
-const { RteField } = createRteField<ContentFormat>({
+const { RteField, RteReadOnly } = createRteField<ContentFormat>({
     rteApiOptions: makeApiOptions, // see ./RteAllOptions for details
     rteOptions, // see ./RteAllOptions for details
 });
 
 function Story() {
-    const [submitedValue, setSubmittedValue] = React.useState<any>();
+    const [submitedValue, setSubmittedValue] = React.useState<{ rteContent: any }>({ rteContent: defaultContent });
 
     return (
-        <div style={{ width: "300px" }}>
-            <Form
-                initialValues={{
-                    rteContent: defaultContent,
-                }}
-                onSubmit={values => {
-                    //
-                    setSubmittedValue(values);
-                }}
-                render={({ handleSubmit }) => (
-                    <form onSubmit={handleSubmit}>
-                        <Field name="rteContent" label="Rich Text" component={RteField} />
-                        <Button type="submit" component={"button"} disableTouchRipple>
-                            Submit
-                        </Button>
-                    </form>
-                )}
-            />
-            <PrintAnything label="This has been submitted">{submitedValue}</PrintAnything>
+        <div>
+            <div style={{ maxWidth: "800px" }}>
+                <Form
+                    initialValues={{
+                        rteContent: defaultContent,
+                    }}
+                    onSubmit={values => {
+                        //
+                        setSubmittedValue(values);
+                    }}
+                    render={({ handleSubmit }) => (
+                        <form onSubmit={handleSubmit}>
+                            <Field name="rteContent" label="Rich Text" component={RteField} />
+                            <Button color="primary" variant="contained" type="submit" component={"button"} disableTouchRipple>
+                                Submit
+                            </Button>
+                        </form>
+                    )}
+                />
+            </div>
+            <Typography variant="h5" color="primary">
+                Readonly Component:
+            </Typography>
+            <RteReadOnly content={submitedValue.rteContent} />
         </div>
     );
 }

--- a/packages/react-admin-stories/src/react-admin-rte/RteReadOnly.tsx
+++ b/packages/react-admin-stories/src/react-admin-rte/RteReadOnly.tsx
@@ -1,0 +1,35 @@
+import { storiesOf } from "@storybook/react";
+import { IRteRef, makeRteApi, RteReadOnly, RteReadOnlyOptions } from "@vivid-planet/react-admin-rte";
+import * as React from "react";
+import { exampleContent, PrintEditorState, RteLayout } from "./helper";
+
+const [useRteApi] = makeRteApi();
+
+const GreenCustomHeader: React.FC = ({ children }) => <span style={{ color: "green" }}>{children}</span>;
+
+const rteOptions: RteReadOnlyOptions = {
+    customBlockMap: {
+        "header-custom-green": {
+            label: "Custom Green Header",
+            renderConfig: {
+                element: "h1",
+                wrapper: <GreenCustomHeader />,
+            },
+        },
+    },
+};
+
+function Story() {
+    const { editorState } = useRteApi({ defaultValue: JSON.stringify(exampleContent) }); // defaultValue is optional
+
+    return (
+        <>
+            <RteLayout>
+                <RteReadOnly value={editorState} options={rteOptions} />
+            </RteLayout>
+            <PrintEditorState editorState={editorState} />
+        </>
+    );
+}
+
+storiesOf("react-admin-rte", module).add("Rte readonly", () => <Story />);


### PR DESCRIPTION
Renders rich-content with the same styles like the normal Rte component. Omits rendering of control-buttons and the input-cursor, optinally renders plain-text only