### PR TITLE
Refactor styling of textfields and selects

### DIFF
--- a/packages/material-ui-react-select/src/Select.tsx
+++ b/packages/material-ui-react-select/src/Select.tsx
@@ -27,7 +27,7 @@ const styles = (theme: Theme) =>
         },
         input: {
             display: "flex",
-            padding: 0,
+            paddingRight: 0,
         },
         valueContainer: {
             display: "flex",
@@ -46,15 +46,12 @@ const styles = (theme: Theme) =>
             padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`,
         },
         singleValue: {
-            fontSize: 16,
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
         },
         placeholder: {
-            position: "absolute",
-            left: 2,
-            fontSize: 16,
+            color: theme.palette.text.disabled,
         },
         paper: {
             position: "absolute",
@@ -117,17 +114,17 @@ function Option<OptionType>(props: OptionProps<OptionType>) {
 
 function Placeholder<OptionType>(props: PlaceholderProps<OptionType>) {
     return (
-        <Typography color="textSecondary" className={props.selectProps.classes.placeholder} {...props.innerProps}>
+        <div className={props.selectProps.classes.placeholder} {...props.innerProps}>
             {props.children}
-        </Typography>
+        </div>
     );
 }
 
 function SingleValue<OptionType>(props: SingleValueProps<OptionType>) {
     return (
-        <Typography className={props.selectProps.classes.singleValue} {...props.innerProps}>
+        <div className={props.selectProps.classes.singleValue} {...props.innerProps}>
             {props.children}
-        </Typography>
+        </div>
     );
 }
 

--- a/packages/react-admin-form/src/Input.tsx
+++ b/packages/react-admin-form/src/Input.tsx
@@ -1,32 +1,10 @@
 import MuiInputBase, { InputBaseProps } from "@material-ui/core/InputBase";
-import { styled } from "@vivid-planet/react-admin-mui";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
-
-export const StyledInput = styled(({ ...props }: InputBaseProps) => <MuiInputBase classes={{ root: "root", focused: "focused" }} {...props} />)<
-    InputBaseProps
->`
-    &.root {
-        border: 1px solid #d8dbdf;
-        border-radius: 2px;
-        background-color: #ffffff;
-        padding: 0px 10px;
-    }
-    textarea {
-        padding: 6px 0px 8px 0;
-    }
-    &.root.focused {
-        border-color: #0081b8;
-    }
-
-    input {
-        height: 19px;
-    }
-`;
 
 export const Input: React.FunctionComponent<InputBaseProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>> = ({
     meta,
     input,
     innerRef,
     ...props
-}) => <StyledInput {...input} {...props} />;
+}) => <MuiInputBase {...input} {...props} />;

--- a/packages/react-admin-form/src/ReactSelect.tsx
+++ b/packages/react-admin-form/src/ReactSelect.tsx
@@ -5,7 +5,6 @@ import {
     ReactSelectAsyncCreatable as AsyncCreatable,
     ReactSelectCreatable as Creatable,
 } from "@vivid-planet/react-admin-final-form-material-ui";
-import { styled } from "@vivid-planet/react-admin-mui";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 import { Props as ReactSelectAsyncProps } from "react-select/async";
@@ -19,9 +18,7 @@ function inputComponent({ inputRef, ...props }: any) {
     return <div ref={inputRef} {...props} />;
 }
 
-export const ControlInput = styled(({ ...props }: InputBaseProps) => (
-    <MuiInputBase classes={{ root: "root", focused: "focused" }} {...props} value={null} />
-))<InputBaseProps>``;
+export const ControlInput = ({ ...props }: InputBaseProps) => <MuiInputBase classes={{ root: "root", focused: "focused" }} {...props} value={null} />;
 
 function Control<OptionType>(props: ControlProps<OptionType>) {
     const InputProps = {

--- a/packages/react-admin-form/src/ReactSelect.tsx
+++ b/packages/react-admin-form/src/ReactSelect.tsx
@@ -18,7 +18,7 @@ function inputComponent({ inputRef, ...props }: any) {
     return <div ref={inputRef} {...props} />;
 }
 
-export const ControlInput = ({ ...props }: InputBaseProps) => <MuiInputBase classes={{ root: "root", focused: "focused" }} {...props} value={null} />;
+export const ControlInput = ({ ...props }: InputBaseProps) => <MuiInputBase classes={{ root: "root", focused: "focused" }} {...props} />;
 
 function Control<OptionType>(props: ControlProps<OptionType>) {
     const InputProps = {

--- a/packages/react-admin-form/src/ReactSelect.tsx
+++ b/packages/react-admin-form/src/ReactSelect.tsx
@@ -19,22 +19,9 @@ function inputComponent({ inputRef, ...props }: any) {
     return <div ref={inputRef} {...props} />;
 }
 
-export const ControlInput = styled(({ ...props }: InputBaseProps) => <MuiInputBase classes={{ root: "root", focused: "focused" }} {...props} />)<
-    InputBaseProps
->`
-    &.root {
-        border: 1px solid #d8dbdf;
-        border-radius: 2px;
-        background-color: #ffffff;
-        padding: 0 0 0 10px;
-    }
-    & .MuiInputBase-input {
-        height: auto;
-    }
-    &.root.focused {
-        border-color: #0081b8;
-    }
-`;
+export const ControlInput = styled(({ ...props }: InputBaseProps) => (
+    <MuiInputBase classes={{ root: "root", focused: "focused" }} {...props} value={null} />
+))<InputBaseProps>``;
 
 function Control<OptionType>(props: ControlProps<OptionType>) {
     const InputProps = {
@@ -50,8 +37,8 @@ function Control<OptionType>(props: ControlProps<OptionType>) {
 }
 
 const vividStyles = {
-    dropdownIndicator: (styles: any) => ({ ...styles, padding: "6px" }),
-    clearIndicator: (styles: any) => ({ ...styles, padding: "6px" }),
+    dropdownIndicator: (styles: any) => ({ ...styles, cursor: "pointer", padding: "6px" }),
+    clearIndicator: (styles: any) => ({ ...styles, cursor: "pointer", padding: "6px" }),
 };
 
 // tslint:disable:max-classes-per-file


### PR DESCRIPTION
Removing styled-component-styles from input and typography from select allows styling the values of inputs and selects through the theme (overrides -> MuiInputBase -> input).

This will break existing projects, adding the following to the theme should re-add the now missing styles:

```js
overrides: {
    MuiInputBase: {
        input: {
            border: "1px solid #d8dbdf",
            borderRadius: "2px",
            padding: "0 10px",
            height: "32px",
        },
    },
},
```