### PR TITLE
Add stackApi and formRenderProps to form buttons-container

### DIFF
--- a/packages/react-admin-core/src/FinalForm.tsx
+++ b/packages/react-admin-core/src/FinalForm.tsx
@@ -10,7 +10,7 @@ import { DirtyHandlerApiContext } from "./DirtyHandlerApiContext";
 import { EditDialogApiContext } from "./EditDialogApiContext";
 import * as sc from "./FinalForm.sc";
 import { renderComponent } from "./finalFormRenderComponent";
-import { StackApiContext } from "./stack";
+import { IStackApi, StackApiContext } from "./stack";
 import { TableQueryContext } from "./table";
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -21,12 +21,20 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
+interface IButtonsContainerProps<FormValues = AnyObject> {
+    stackApi?: IStackApi;
+    formRenderProps: FormRenderProps<FormValues>;
+}
+
+
 interface IProps<FormValues = AnyObject> extends FormProps<FormValues> {
     mode: "edit" | "add";
     components?: {
-        buttonsContainer?: React.ComponentType;
+        buttonsContainer?: React.ComponentType<IButtonsContainerProps<FormValues>>;
     };
 }
+
+
 
 export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
     const classes = useStyles();
@@ -100,7 +108,7 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
                         {formRenderProps.submitting && <CircularProgress />}
                         {!formRenderProps.submitting && (
                             <>
-                                <ButtonsContainer>
+                                <ButtonsContainer stackApi={stackApi} formRenderProps={formRenderProps}>
                                     {stackApi && (
                                         <Button
                                             className={classes.saveButton}

--- a/packages/react-admin-core/src/FinalForm.tsx
+++ b/packages/react-admin-core/src/FinalForm.tsx
@@ -10,7 +10,7 @@ import { DirtyHandlerApiContext } from "./DirtyHandlerApiContext";
 import { EditDialogApiContext } from "./EditDialogApiContext";
 import * as sc from "./FinalForm.sc";
 import { renderComponent } from "./finalFormRenderComponent";
-import { IStackApi, StackApiContext } from "./stack";
+import { StackApiContext } from "./stack";
 import { TableQueryContext } from "./table";
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -21,20 +21,13 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 );
 
-interface IButtonsContainerProps<FormValues = AnyObject> {
-    stackApi?: IStackApi;
-    formRenderProps: FormRenderProps<FormValues>;
-}
-
-
 interface IProps<FormValues = AnyObject> extends FormProps<FormValues> {
     mode: "edit" | "add";
     components?: {
-        buttonsContainer?: React.ComponentType<IButtonsContainerProps<FormValues>>;
+        buttonsContainer?: React.ComponentType;
     };
+    renderButtons?: (formRenderProps: FormRenderProps<FormValues>) => React.ReactNode;
 }
-
-
 
 export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
     const classes = useStyles();
@@ -108,29 +101,33 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
                         {formRenderProps.submitting && <CircularProgress />}
                         {!formRenderProps.submitting && (
                             <>
-                                <ButtonsContainer stackApi={stackApi} formRenderProps={formRenderProps}>
-                                    {stackApi && (
+                                {props.renderButtons ? (
+                                    props.renderButtons(formRenderProps)
+                                ) : (
+                                    <ButtonsContainer>
+                                        {stackApi && (
+                                            <Button
+                                                className={classes.saveButton}
+                                                startIcon={<CancelIcon />}
+                                                variant="text"
+                                                color="default"
+                                                onClick={handleCancelClick}
+                                            >
+                                                Abbrechen
+                                            </Button>
+                                        )}
                                         <Button
                                             className={classes.saveButton}
-                                            startIcon={<CancelIcon />}
-                                            variant="text"
-                                            color="default"
-                                            onClick={handleCancelClick}
+                                            startIcon={<SaveIcon />}
+                                            variant="contained"
+                                            color="primary"
+                                            type="submit"
+                                            disabled={formRenderProps.pristine || formRenderProps.hasValidationErrors || formRenderProps.submitting}
                                         >
-                                            Abbrechen
+                                            Speichern
                                         </Button>
-                                    )}
-                                    <Button
-                                        className={classes.saveButton}
-                                        startIcon={<SaveIcon />}
-                                        variant="contained"
-                                        color="primary"
-                                        type="submit"
-                                        disabled={formRenderProps.pristine || formRenderProps.hasValidationErrors || formRenderProps.submitting}
-                                    >
-                                        Speichern
-                                    </Button>
-                                </ButtonsContainer>
+                                    </ButtonsContainer>
+                                )}
                             </>
                         )}
                     </>

--- a/packages/react-admin-stories/src/react-admin-core/FormCustomButtons.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/FormCustomButtons.tsx
@@ -1,9 +1,8 @@
 import { ApolloProvider } from "@apollo/react-hooks";
 import { Button } from "@material-ui/core";
-import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 import { BeachAccess as BeachAccessIcon } from "@material-ui/icons";
 import { storiesOf } from "@storybook/react";
-import { FinalForm, IStackApi } from "@vivid-planet/react-admin-core";
+import { FinalForm } from "@vivid-planet/react-admin-core";
 import { Field, FormPaper, Input } from "@vivid-planet/react-admin-form";
 import { styled } from "@vivid-planet/react-admin-mui";
 import { InMemoryCache } from "apollo-cache-inmemory";
@@ -11,11 +10,10 @@ import ApolloClient from "apollo-client";
 import { ApolloLink } from "apollo-link";
 import { RestLink } from "apollo-link-rest";
 import * as React from "react";
-import { FormRenderProps } from "react-final-form";
+import { AnyObject } from "react-final-form";
 
-interface IComponentProps {
-    stackApi?: IStackApi;
-    formRenderProps: FormRenderProps;
+interface IProps {
+    formRenderProps: AnyObject;
 }
 
 const StyledButton = styled(Button)`
@@ -23,32 +21,19 @@ const StyledButton = styled(Button)`
         text-transform: capitalize;
         background-color: #006699;
         color: white;
-
         &:disabled {
             color: lightgrey;
             background-color: slategrey;
         }
-
         &:hover {
             background-color: #006699;
         }
     }
 `;
 
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        saveButton: {
-            margin: theme.spacing(1),
-        },
-    }),
-);
-
-const CustomFormButtonsContainer: React.FC<IComponentProps> = ({ formRenderProps }) => {
-    const classes = useStyles();
-
+const FormCustomButtons: React.FC<IProps> = ({ formRenderProps }) => {
     return (
         <StyledButton
-            className={classes.saveButton}
             startIcon={<BeachAccessIcon />}
             variant="text"
             color="default"
@@ -71,11 +56,7 @@ function Story() {
             onSubmit={() => {
                 // add your form-submit function here
             }}
-            initialValues={{
-                foo: "foo",
-                bar: "bar",
-            }}
-            components={{ buttonsContainer: CustomFormButtonsContainer }}
+            renderButtons={props => <FormCustomButtons formRenderProps={props} />}
         >
             <FormPaper>
                 <Field label="Foo" name="foo" component={Input} />
@@ -102,4 +83,4 @@ storiesOf("react-admin-core", module)
 
         return <ApolloProvider client={client}>{story()}</ApolloProvider>;
     })
-    .add("FormCustomButtonsContainer", () => <Story />);
+    .add("FormCustomButtons", () => <Story />);

--- a/packages/react-admin-stories/src/react-admin-core/FormCustomButtonsContainer.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/FormCustomButtonsContainer.tsx
@@ -1,0 +1,105 @@
+import { ApolloProvider } from "@apollo/react-hooks";
+import { Button } from "@material-ui/core";
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+import { BeachAccess as BeachAccessIcon } from "@material-ui/icons";
+import { storiesOf } from "@storybook/react";
+import { FinalForm, IStackApi } from "@vivid-planet/react-admin-core";
+import { Field, FormPaper, Input } from "@vivid-planet/react-admin-form";
+import { styled } from "@vivid-planet/react-admin-mui";
+import { InMemoryCache } from "apollo-cache-inmemory";
+import ApolloClient from "apollo-client";
+import { ApolloLink } from "apollo-link";
+import { RestLink } from "apollo-link-rest";
+import * as React from "react";
+import { FormRenderProps } from "react-final-form";
+
+interface IComponentProps {
+    stackApi?: IStackApi;
+    formRenderProps: FormRenderProps;
+}
+
+const StyledButton = styled(Button)`
+    && {
+        text-transform: capitalize;
+        background-color: #006699;
+        color: white;
+
+        &:disabled {
+            color: lightgrey;
+            background-color: slategrey;
+        }
+
+        &:hover {
+            background-color: #006699;
+        }
+    }
+`;
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        saveButton: {
+            margin: theme.spacing(1),
+        },
+    }),
+);
+
+const CustomFormButtonsContainer: React.FC<IComponentProps> = ({ formRenderProps }) => {
+    const classes = useStyles();
+
+    return (
+        <StyledButton
+            className={classes.saveButton}
+            startIcon={<BeachAccessIcon />}
+            variant="text"
+            color="default"
+            disabled={formRenderProps.pristine || formRenderProps.hasValidationErrors || formRenderProps.submitting}
+            onClick={handleCustomButtonClick}
+        >
+            {formRenderProps.pristine ? "Please fill out the form" : "Click Me - I'm a Custom button"}
+        </StyledButton>
+    );
+
+    function handleCustomButtonClick() {
+        window.alert(`Form values: ${JSON.stringify(formRenderProps.values)}`);
+    }
+};
+
+function Story() {
+    return (
+        <FinalForm
+            mode={"edit"}
+            onSubmit={() => {
+                // add your form-submit function here
+            }}
+            initialValues={{
+                foo: "foo",
+                bar: "bar",
+            }}
+            components={{ buttonsContainer: CustomFormButtonsContainer }}
+        >
+            <FormPaper>
+                <Field label="Foo" name="foo" component={Input} />
+                <Field label="Bar" name="bar" component={Input} />
+            </FormPaper>
+        </FinalForm>
+    );
+}
+
+storiesOf("react-admin-core", module)
+    .addDecorator(story => {
+        const link = ApolloLink.from([
+            new RestLink({
+                uri: "https://jsonplaceholder.typicode.com/",
+            }),
+        ]);
+
+        const cache = new InMemoryCache();
+
+        const client = new ApolloClient({
+            link,
+            cache,
+        });
+
+        return <ApolloProvider client={client}>{story()}</ApolloProvider>;
+    })
+    .add("FormCustomButtonsContainer", () => <Story />);


### PR DESCRIPTION
Sometimes it is necessary to not only be able to style the form-buttons, but also change their behaviour.
An example is the redirect after submit - in some cases this might not be a desired behaviour. In other cases you might only want to render one button (e.g. only save without cancel) or an additional custom button. It is therefore useful for the custom ButtonsContainer to have access to the stackApi (if it exists) as well as the formRenderProps.