### PR TITLE
Fix CI-Linting-error and ref-warnings

### DIFF
--- a/packages/react-admin-rte/src/core/Controls/FeaturesButtonGroup.tsx
+++ b/packages/react-admin-rte/src/core/Controls/FeaturesButtonGroup.tsx
@@ -20,7 +20,9 @@ export default function FeaturesButtonGroup({ features }: IProps) {
                 <sc.ButtonWrapper key={name}>
                     {tooltipText ? (
                         <Tooltip title={tooltipText} placement="top">
-                            <ControlButton onButtonClick={onButtonClick} {...rest} />
+                            <span>
+                                <ControlButton onButtonClick={onButtonClick} {...rest} />
+                            </span>
                         </Tooltip>
                     ) : (
                         <ControlButton onButtonClick={onButtonClick} {...rest} />

--- a/packages/react-admin-rte/src/core/RteReadOnly.tsx
+++ b/packages/react-admin-rte/src/core/RteReadOnly.tsx
@@ -26,7 +26,9 @@ const RteReadOnly: React.FC<IProps> = ({ value: editorState, options: passedOpti
     const blockRenderMap = createBlockRenderMap({ customBlockTypeMap: options.customBlockMap });
 
     function handleOnChange() {
-        editorRef.current && editorRef.current.blur();
+        if (editorRef.current) {
+            editorRef.current.blur();
+        }
     }
 
     if (plainTextOnly) {


### PR DESCRIPTION
Fixes:

- `ERROR: /opt/app-root/src/packages/react-admin-rte/src/core/RteReadOnly.tsx:29:9 - unused expression, expected an assignment or function call`

- ref Warnings in `FeaturesButtonGroup`
![Bildschirmfoto 2020-07-15 um 17 17 24](https://user-images.githubusercontent.com/17711865/87564211-6e040880-c6c0-11ea-868e-1a47afb1e58b.png)