### PR TITLE
enhance drag and drop

### DIFF
--- a/packages/react-admin-core/src/table/TableDndOrder.tsx
+++ b/packages/react-admin-core/src/table/TableDndOrder.tsx
@@ -70,6 +70,7 @@ function cardTargetHover<TRow extends IRow>(props: IDndOrderRowProps<TRow>, moni
 
 interface IDndOrderRowProps<TRow extends IRow> extends ITableRowProps<TRow> {
     moveRow: (dragIndex: number, hoverIndex: number) => void;
+    onDragEnd?: () => void;
 }
 
 interface IRowCollectedSourceProps {
@@ -87,7 +88,7 @@ class DndOrderRow<TRow extends IRow> extends React.Component<IDndOrderRowProps<T
         return (
             <RootRef rootRef={this.handleRootRef}>
                 <TableBodyRow {...rowProps} style={{ opacity }}>
-                    <TableCell>{connectDragSource(<span style={{ padding: 5 }}>::</span>)}</TableCell>
+                    <TableCell>{connectDragSource(<span style={{ padding: 5, cursor: "grab" }}>::</span>)}</TableCell>
                     <TableColumns columns={columns} row={row} />
                 </TableBodyRow>
             </RootRef>
@@ -105,6 +106,11 @@ const ExtendedDndOrderRow = DragSource<IDndOrderRowProps<IRow>, IRowCollectedSou
     "row", // TODO: configurable? unique per table?
     {
         beginDrag: cardSourceBeginDrag,
+        endDrag: props => {
+            if (props.onDragEnd) {
+                props.onDragEnd();
+            }
+        },
     },
     (connect, monitor) => ({
         connectDragSource: connect.dragSource(),
@@ -125,6 +131,7 @@ const ExtendedDndOrderRow = DragSource<IDndOrderRowProps<IRow>, IRowCollectedSou
 
 interface IProps<TRow extends IRow> extends ITableProps<TRow> {
     moveRow: (dragIndex: number, hoverIndex: number) => void;
+    onDragEnd?: () => void;
 }
 
 // tslint:disable-next-line:max-classes-per-file
@@ -133,7 +140,7 @@ class TableDndOrder<TRow extends IRow> extends React.Component<IProps<TRow>> {
         const tableProps: ITableProps<TRow> = {
             ...this.props,
             renderTableRow: props => {
-                return <ExtendedDndOrderRow moveRow={this.props.moveRow} index={props.index} {...props} />;
+                return <ExtendedDndOrderRow moveRow={this.props.moveRow} onDragEnd={this.props.onDragEnd} index={props.index} {...props} />;
             },
             renderHeadTableRow: props => {
                 return (

--- a/packages/react-admin-core/src/table/TableLocalChanges.tsx
+++ b/packages/react-admin-core/src/table/TableLocalChanges.tsx
@@ -29,6 +29,7 @@ export interface ITableLocalChangesApi {
 interface IProps<TData> {
     data: TData[];
     onSubmit: (changes: { [id: string]: Partial<TData> }) => Promise<void>;
+    posProp: string;
     children: (injectedProps: {
         tableLocalChangesApi: ITableLocalChangesApi;
         localChangesCount: number;
@@ -43,9 +44,13 @@ interface IState<TData> {
     };
     loading: boolean;
 }
-export class TableLocalChanges<TData extends { id: string; pos?: number }> extends React.Component<IProps<TData>, IState<TData>> {
+export class TableLocalChanges<TData extends { id: string; [key: string]: any }> extends React.Component<IProps<TData>, IState<TData>> {
     public static contextType = DirtyHandlerApiContext;
+    protected static defaultProps = {
+        posProp: "pos",
+    };
     private tableLocalChangesApi: ITableLocalChangesApi;
+
     constructor(props: IProps<TData>) {
         super(props);
         this.tableLocalChangesApi = {
@@ -146,7 +151,7 @@ export class TableLocalChanges<TData extends { id: string; pos?: number }> exten
 
         const hoverId = changedOrder[hoverIndex];
         const hoverRow = patchedData.find(i => i.id === hoverId);
-        this.setLocalDataChange(dragId, "pos", hoverRow.pos);
+        this.setLocalDataChange(dragId, this.props.posProp, hoverRow[this.props.posProp]);
 
         changedOrder.splice(dragIndex, 1);
         changedOrder.splice(hoverIndex, 0, dragId);

--- a/packages/react-admin-core/src/table/TableLocalChanges.tsx
+++ b/packages/react-admin-core/src/table/TableLocalChanges.tsx
@@ -29,7 +29,7 @@ export interface ITableLocalChangesApi {
 interface IProps<TData> {
     data: TData[];
     onSubmit: (changes: { [id: string]: Partial<TData> }) => Promise<void>;
-    posProp: string;
+    orderColumn: string;
     children: (injectedProps: {
         tableLocalChangesApi: ITableLocalChangesApi;
         localChangesCount: number;
@@ -47,7 +47,7 @@ interface IState<TData> {
 export class TableLocalChanges<TData extends { id: string; [key: string]: any }> extends React.Component<IProps<TData>, IState<TData>> {
     public static contextType = DirtyHandlerApiContext;
     protected static defaultProps = {
-        posProp: "pos",
+        orderColumn: "pos",
     };
     private tableLocalChangesApi: ITableLocalChangesApi;
 
@@ -151,7 +151,7 @@ export class TableLocalChanges<TData extends { id: string; [key: string]: any }>
 
         const hoverId = changedOrder[hoverIndex];
         const hoverRow = patchedData.find(i => i.id === hoverId);
-        this.setLocalDataChange(dragId, this.props.posProp, hoverRow[this.props.posProp]);
+        this.setLocalDataChange(dragId, this.props.orderColumn, hoverRow[this.props.orderColumn]);
 
         changedOrder.splice(dragIndex, 1);
         changedOrder.splice(hoverIndex, 0, dragId);

--- a/packages/react-admin-stories/src/react-admin-core/TableDndOrder.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/TableDndOrder.tsx
@@ -24,7 +24,7 @@ function Story() {
             onSubmit={async changes => {
                 alert(JSON.stringify(changes));
             }}
-            posProp="order" // if anything but 'pos' is used
+            orderColumn="order" // if anything but 'pos' is used
         >
             {({ tableLocalChangesApi, data: changedData }) => (
                 <>

--- a/packages/react-admin-stories/src/react-admin-core/TableDndOrder.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/TableDndOrder.tsx
@@ -5,13 +5,18 @@ import * as React from "react";
 
 interface IRow {
     id: string; // TODO add support for number in TableLocalChanges
-    pos: number;
-    foo1: string;
-    foo2: string;
+    order: number;
+    task: string;
 }
 
 function Story() {
-    const data: IRow[] = [{ id: "1", pos: 1, foo1: "blub", foo2: "blub1" }, { id: "2", pos: 2, foo1: "blub", foo2: "blub2" }];
+    const data: IRow[] = [
+        { id: "1", order: 1, task: "Write a cool JS library" },
+        { id: "2", order: 2, task: "Make it generic enough" },
+        { id: "3", order: 3, task: "Write README" },
+        { id: "4", order: 4, task: "Create some examples" },
+        { id: "5", order: 5, task: "PROFIT" },
+    ];
 
     return (
         <TableLocalChanges
@@ -19,6 +24,7 @@ function Story() {
             onSubmit={async changes => {
                 alert(JSON.stringify(changes));
             }}
+            posProp="order" // if anything but 'pos' is used
         >
             {({ tableLocalChangesApi, data: changedData }) => (
                 <>
@@ -26,15 +32,14 @@ function Story() {
                         data={changedData}
                         totalCount={changedData.length}
                         moveRow={tableLocalChangesApi.moveRow}
+                        onDragEnd={() => {
+                            // alternative to submit button
+                            // tableLocalChangesApi.submitLocalDataChanges();
+                        }}
                         columns={[
                             {
-                                name: "foo1",
-                                header: "Foo1",
-                            },
-                            {
-                                name: "foo2",
-                                header: "Foo2",
-                                render: row => <strong>{row.foo2}</strong>,
+                                name: "task",
+                                header: "Task",
                             },
                         ]}
                     />


### PR DESCRIPTION
This PR addresses the following things: 
- add possibility to override prop used for ordering (posProp)
- add callback for onDragEnd (as an alternative to submit through a button)
- add visual hint for drag handle (cursor)
- make dnd table example more sophisticated

On the long run we should consider updating to react-dnd v11, because v8 is marked as deprecated.