### PR TITLE
Allow customizing selects and inputs in mui-theme

### DIFF
--- a/packages/material-ui-react-select/src/Select.styles.ts
+++ b/packages/material-ui-react-select/src/Select.styles.ts
@@ -1,0 +1,95 @@
+import { Theme } from "@material-ui/core";
+import { emphasize } from "@material-ui/core/styles/colorManipulator";
+import zIndex from "@material-ui/core/styles/zIndex";
+import { createStyles } from "@material-ui/styles";
+
+// TODO: import from "@vivid-planet/react-admin-form" after publish.
+const getDefaultVPAdminInputStyles = (theme: Theme) => {
+    return {
+        border: `1px solid ${theme.palette.grey[300]}`,
+        borderRadius: "2px",
+        padding: "0 10px",
+        height: "32px",
+    };
+};
+
+export type VPAdminSelectClassKeys =
+    | "input"
+    | "valueContainer"
+    | "chip"
+    | "chipFocused"
+    | "noOptionsMessage"
+    | "singleValue"
+    | "placeholder"
+    | "paper"
+    | "indicatorsContainer"
+    | "indicatorSeparator"
+    | "clearIndicator"
+    | "indicator"
+    | "dropdownIndicator";
+
+const styles = (theme: Theme) =>
+    createStyles({
+        input: {
+            ...getDefaultVPAdminInputStyles(theme),
+            display: "flex",
+            paddingRight: 0,
+        },
+        valueContainer: {
+            display: "flex",
+            flexWrap: "nowrap",
+            flex: 1,
+            alignItems: "center",
+            overflow: "hidden",
+        },
+        chip: {
+            margin: `${theme.spacing(0.5)}px ${theme.spacing(0.25)}px`,
+        },
+        chipFocused: {
+            backgroundColor: emphasize(theme.palette.type === "light" ? theme.palette.grey[300] : theme.palette.grey[700], 0.08),
+        },
+        noOptionsMessage: {
+            padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`,
+            color: theme.palette.text.secondary,
+        },
+        singleValue: {
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+        },
+        placeholder: {
+            color: theme.palette.text.disabled,
+        },
+        paper: {
+            position: "absolute",
+            zIndex: zIndex.modal,
+            left: 0,
+            right: 0,
+        },
+        indicatorsContainer: {
+            display: "flex",
+        },
+        indicatorSeparator: {
+            width: 1,
+            flexGrow: 1,
+            marginTop: theme.spacing(1),
+            marginBottom: theme.spacing(1),
+            backgroundColor: theme.palette.divider,
+        },
+        indicator: {
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: theme.palette.grey[500],
+            width: 32,
+            cursor: "pointer",
+        },
+        clearIndicator: {
+            fontSize: 18,
+        },
+        dropdownIndicator: {
+            fontSize: 20,
+        },
+    });
+
+export default styles;

--- a/packages/material-ui-react-select/src/index.ts
+++ b/packages/material-ui-react-select/src/index.ts
@@ -1,1 +1,2 @@
-export * from "./Select";
+export { ReactSelect, ReactSelectAsync, ReactSelectAsyncCreatable, ReactSelectCreatable } from "./Select";
+export * from "./themeAugmentation";

--- a/packages/material-ui-react-select/src/themeAugmentation.ts
+++ b/packages/material-ui-react-select/src/themeAugmentation.ts
@@ -1,0 +1,16 @@
+import { IVPAdminSelectProps } from "./Select";
+import { VPAdminSelectClassKeys } from "./Select.styles";
+
+declare module "@material-ui/core/styles/overrides" {
+    // tslint:disable-next-line:interface-name
+    interface ComponentNameToClassKey {
+        VPAdminSelect: VPAdminSelectClassKeys;
+    }
+}
+
+declare module "@material-ui/core/styles/props" {
+    // tslint:disable-next-line:interface-name
+    interface ComponentsPropsList {
+        VPAdminSelect: IVPAdminSelectProps<any>;
+    }
+}

--- a/packages/react-admin-form/package.json
+++ b/packages/react-admin-form/package.json
@@ -16,6 +16,7 @@
     },
     "peerDependencies": {
         "@material-ui/core": "^4.1.3",
+        "@material-ui/styles": "^4.1.3",
         "@material-ui/icons": "^4.2.1",
         "@vivid-planet/react-admin-date-fns": "^1.0.0-alpha.0",
         "@vivid-planet/react-admin-final-form-material-ui": "^1.0.0-alpha.0",

--- a/packages/react-admin-form/src/Input.tsx
+++ b/packages/react-admin-form/src/Input.tsx
@@ -1,10 +1,32 @@
+import { Theme } from "@material-ui/core";
 import MuiInputBase, { InputBaseProps } from "@material-ui/core/InputBase";
+import { createStyles, withStyles } from "@material-ui/styles";
 import * as React from "react";
 import { FieldRenderProps } from "react-final-form";
 
-export const Input: React.FunctionComponent<InputBaseProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>> = ({
+export type VPAdminInputClassKeys = "input";
+
+export const getDefaultVPAdminInputStyles = (theme: Theme) => {
+    return {
+        border: `1px solid ${theme.palette.grey[300]}`,
+        borderRadius: "2px",
+        padding: "0 10px",
+        height: "32px",
+    };
+};
+
+const styles = (theme: Theme) =>
+    createStyles({
+        input: getDefaultVPAdminInputStyles(theme),
+    });
+
+const InputBase: React.FunctionComponent<InputBaseProps & FieldRenderProps<string, HTMLInputElement | HTMLTextAreaElement>> = ({
     meta,
     input,
     innerRef,
     ...props
-}) => <MuiInputBase {...input} {...props} />;
+}) => {
+    return <MuiInputBase {...input} {...props} />;
+};
+
+export const Input = withStyles(styles, { name: "VPAdminInputBase", withTheme: true })(InputBase);

--- a/packages/react-admin-form/src/index.ts
+++ b/packages/react-admin-form/src/index.ts
@@ -6,3 +6,4 @@ export * from "./FormSection";
 export * from "./Input";
 export * from "./ReactSelect";
 export * from "./ReactSelectStaticOptions";
+export * from "./themeAugmentation";

--- a/packages/react-admin-form/src/themeAugmentation.ts
+++ b/packages/react-admin-form/src/themeAugmentation.ts
@@ -1,0 +1,8 @@
+import { VPAdminInputClassKeys } from "./Input";
+
+declare module "@material-ui/core/styles/overrides" {
+    // tslint:disable-next-line:interface-name
+    interface ComponentNameToClassKey {
+        VPAdminInputBase: VPAdminInputClassKeys;
+    }
+}

--- a/packages/react-admin-stories/src/react-admin-form/ReactSelect.tsx
+++ b/packages/react-admin-stories/src/react-admin-form/ReactSelect.tsx
@@ -30,7 +30,6 @@ function Story() {
                             label="Flavor"
                             fieldContainerComponent={FieldContainerLabelAbove}
                             component={ReactSelectStaticOptions}
-                            placeholder=""
                             isClearable
                             defaultOptions
                             options={options}


### PR DESCRIPTION
Based on theme-augmentation from "@material-ui/lab":
- https://github.com/mui-org/material-ui/blob/next/packages/material-ui-lab/src/themeAugmentation/index.d.ts
- https://github.com/mui-org/material-ui/blob/next/packages/material-ui-lab/src/themeAugmentation/overrides.d.ts
- https://github.com/mui-org/material-ui/blob/next/packages/material-ui-lab/src/themeAugmentation/props.d.ts

Globally change icons used in select example:

```ts
// tslint:disable-next-line:no-submodule-imports
import "@vivid-planet/material-ui-react-select/src/themeAugmentation";
import { ArrowDropDown, ArrowDropUp, Delete } from "@material-ui/icons";
import { createMuiTheme } from "@vivid-planet/react-admin-mui";

const theme = createMuiTheme({
    props: {
        VPAdminSelect: {
            clearIcon: Delete,
            dropdownIcon: ArrowDropDown,
            dropdownIconOpen: ArrowDropUp,
        },
    },
});
```

Globally style select example:

```ts
// tslint:disable-next-line:no-submodule-imports
import "@vivid-planet/material-ui-react-select/src/themeAugmentation";
import { createMuiTheme } from "@vivid-planet/react-admin-mui";

const theme = createMuiTheme({
    overrides: {
        VPAdminSelect: {
            input: {
                border: "1px solid lime",
                borderRadius: 0
            },
            indicatorSeparator: {
                backgroundColor: 'red'
            }
        },
    },
});
```

Globally style inputs example:

```ts
// tslint:disable-next-line:no-submodule-imports
import "@vivid-planet/react-admin-form/src/themeAugmentation";
import { createMuiTheme } from "@vivid-planet/react-admin-mui";

const theme = createMuiTheme({
    overrides: {
        VPAdminInputBase: {
            input: {
                border: "1px solid lime",
                borderRadius: 0,
            },
        },
    },
});
```