### PR TITLE
Add param to prevent scrolling to table top on filter

### DIFF
--- a/packages/react-admin-core/src/table/useTableQueryFilter.tsx
+++ b/packages/react-admin-core/src/table/useTableQueryFilter.tsx
@@ -14,9 +14,6 @@ export function useTableQueryFilter<FilterValues extends AnyObject>(
     options: {
         pagingApi?: IPagingApi<any>;
         persistedStateId?: string;
-        noScrollToTableTopOnFilter?: boolean;
-    } = {
-        noScrollToTableTopOnFilter: false,
     },
 ): IFilterApi<FilterValues> {
     const [filters, setFilters] = usePersistedState<FilterValues>(defaultValues, {
@@ -40,7 +37,7 @@ export function useTableQueryFilter<FilterValues extends AnyObject>(
                 if (!isEqual(filters, newValues)) {
                     setFilters(newValues);
                     if (options.pagingApi) {
-                        options.pagingApi.changePage(options.pagingApi.init, 1, { noScrollToTop: options.noScrollToTableTopOnFilter });
+                        options.pagingApi.changePage(options.pagingApi.init, 1, { noScrollToTop: true });
                     }
                 }
             }, 500),

--- a/packages/react-admin-core/src/table/useTableQueryFilter.tsx
+++ b/packages/react-admin-core/src/table/useTableQueryFilter.tsx
@@ -14,7 +14,7 @@ export function useTableQueryFilter<FilterValues extends AnyObject>(
     options: {
         pagingApi?: IPagingApi<any>;
         persistedStateId?: string;
-    },
+    } = {},
 ): IFilterApi<FilterValues> {
     const [filters, setFilters] = usePersistedState<FilterValues>(defaultValues, {
         persistedStateId: options.persistedStateId ? options.persistedStateId + "_filter" : undefined,

--- a/packages/react-admin-core/src/table/useTableQueryFilter.tsx
+++ b/packages/react-admin-core/src/table/useTableQueryFilter.tsx
@@ -14,7 +14,10 @@ export function useTableQueryFilter<FilterValues extends AnyObject>(
     options: {
         pagingApi?: IPagingApi<any>;
         persistedStateId?: string;
-    } = {},
+        noScrollToTableTopOnFilter?: boolean;
+    } = {
+        noScrollToTableTopOnFilter: false,
+    },
 ): IFilterApi<FilterValues> {
     const [filters, setFilters] = usePersistedState<FilterValues>(defaultValues, {
         persistedStateId: options.persistedStateId ? options.persistedStateId + "_filter" : undefined,
@@ -37,7 +40,7 @@ export function useTableQueryFilter<FilterValues extends AnyObject>(
                 if (!isEqual(filters, newValues)) {
                     setFilters(newValues);
                     if (options.pagingApi) {
-                        options.pagingApi.changePage(options.pagingApi.init, 1);
+                        options.pagingApi.changePage(options.pagingApi.init, 1, options.noScrollToTableTopOnFilter);
                     }
                 }
             }, 500),

--- a/packages/react-admin-core/src/table/useTableQueryFilter.tsx
+++ b/packages/react-admin-core/src/table/useTableQueryFilter.tsx
@@ -40,7 +40,7 @@ export function useTableQueryFilter<FilterValues extends AnyObject>(
                 if (!isEqual(filters, newValues)) {
                     setFilters(newValues);
                     if (options.pagingApi) {
-                        options.pagingApi.changePage(options.pagingApi.init, 1, options.noScrollToTableTopOnFilter);
+                        options.pagingApi.changePage(options.pagingApi.init, 1, { noScrollToTop: options.noScrollToTableTopOnFilter });
                     }
                 }
             }, 500),

--- a/packages/react-admin-core/src/table/useTableQueryPaging.tsx
+++ b/packages/react-admin-core/src/table/useTableQueryPaging.tsx
@@ -5,9 +5,14 @@ export interface IPagingApi<T> {
     init: T;
     current: T;
     currentPage?: number;
-    changePage: (variables: T, page?: number, noScrollToTop?: boolean) => void;
+    changePage: (variables: T, page?: number, changePageOptions?: IChangePageOptions) => void;
     attachTableRef: (ref: React.RefObject<HTMLDivElement | undefined>) => void;
 }
+
+export interface IChangePageOptions {
+    noScrollToTop?: boolean;
+}
+
 export function useTableQueryPaging<T>(
     init: T,
     options: {
@@ -26,10 +31,10 @@ export function useTableQueryPaging<T>(
         tableRef = ref;
     }
 
-    function changePage(vars: T, p?: number, noScrollToTop?: boolean) {
+    function changePage(vars: T, p?: number, changePageOptions?: IChangePageOptions) {
         setVariables(vars);
         if (p) setPage(p);
-        if (tableRef && tableRef.current && !noScrollToTop) {
+        if (tableRef && tableRef.current && !changePageOptions?.noScrollToTop) {
             tableRef.current.scrollIntoView();
         }
     }

--- a/packages/react-admin-core/src/table/useTableQueryPaging.tsx
+++ b/packages/react-admin-core/src/table/useTableQueryPaging.tsx
@@ -5,7 +5,7 @@ export interface IPagingApi<T> {
     init: T;
     current: T;
     currentPage?: number;
-    changePage: (variables: T, page?: number) => void;
+    changePage: (variables: T, page?: number, noScrollToTop?: boolean) => void;
     attachTableRef: (ref: React.RefObject<HTMLDivElement | undefined>) => void;
 }
 export function useTableQueryPaging<T>(
@@ -26,10 +26,10 @@ export function useTableQueryPaging<T>(
         tableRef = ref;
     }
 
-    function changePage(vars: T, p?: number) {
+    function changePage(vars: T, p?: number, noScrollToTop?: boolean) {
         setVariables(vars);
         if (p) setPage(p);
-        if (tableRef && tableRef.current) {
+        if (tableRef && tableRef.current && !noScrollToTop) {
             tableRef.current.scrollIntoView();
         }
     }


### PR DESCRIPTION
Löst das Problem, dass bei jedem Filter-Vorgang einer Table zum Anfang der Table gescrollt wird, was dann die Filter-Felder verdeckt.

Dieses Verhalten kann jetzt über einen Parameter ein- oder ausgeschalten werden. Per Default ist das Verhalten aktiviert, um mit bestehenden Projekten, die sich auf dieses Verhalten verlassen, kompatibel zu sein. (Falls es solche gibt, denn meiner Ansicht nach handelt es sich hier um einen Bug, bei dem das Scrollen ein ungewollter Sideeffect ist. Daher könnte der Default-Wert auch noch auf `noScrollToTableTopOnFilter: true` geändert werden.)