### PR TITLE
Fix z-index of loading-animation in TableQuery-component

### DIFF
--- a/packages/react-admin-core/src/table/TableQuery.sc.ts
+++ b/packages/react-admin-core/src/table/TableQuery.sc.ts
@@ -1,3 +1,4 @@
+import zIndex from "@material-ui/core/styles/zIndex";
 import styled from "styled-components";
 
 export const ProgressOverlayContainer = styled.div`
@@ -9,6 +10,7 @@ export const ProgressOverlayInnerContainer = styled.div`
     position: sticky;
     width: 100%;
     top: 0;
+    z-index: ${zIndex.modal};
 `;
 
 export const TableCircularProgressContainer = styled.div`


### PR DESCRIPTION
Der Z-index für die Loading-Animation in der TableQuery-Komponente passt nicht:
![Bildschirmfoto 2020-09-17 um 14 10 55](https://user-images.githubusercontent.com/17711865/93468718-b1ad0580-f8ef-11ea-93d2-415659bbdb2e.png)