### PR TITLE
Filter rte state

### DIFF
--- a/packages/react-admin-rte/src/core/filterEditor/default.ts
+++ b/packages/react-admin-rte/src/core/filterEditor/default.ts
@@ -1,0 +1,17 @@
+import { FilterEditorStateBeforeUpdateFn } from "../Rte";
+import removeUnsupportedBlocks from "./removeUnsupportedBlocks";
+import removeUnsupportedEntities from "./removeUnsupportedEntities";
+import removeUnsupportedInlineStyles from "./removeUnsupportedInlineStyles";
+
+const defaultFilterEditorStateBeforeUpdate: FilterEditorStateBeforeUpdateFn = (newState, ctx) => {
+    const fns: FilterEditorStateBeforeUpdateFn[] = [removeUnsupportedEntities, removeUnsupportedBlocks, removeUnsupportedInlineStyles];
+
+    const shouldFilter = newState.getLastChangeType() === "insert-fragment";
+    if (shouldFilter) {
+        // apply all filters from left to right
+        return fns.reduce((nextState, filterFn) => filterFn(nextState, ctx), newState);
+    }
+    return newState;
+};
+
+export default defaultFilterEditorStateBeforeUpdate;

--- a/packages/react-admin-rte/src/core/filterEditor/removeUnsupportedBlocks.ts
+++ b/packages/react-admin-rte/src/core/filterEditor/removeUnsupportedBlocks.ts
@@ -1,0 +1,30 @@
+import { DraftBlockType, Editor as DraftJsEditor, EditorProps as DraftJsEditorProps } from "draft-js";
+import { FilterEditorStateBeforeUpdateFn, SuportedThings } from "../Rte";
+import { FilterEditorStateFn, InlineStyleType } from "../types";
+import unstyleBlocks from "./utils/unstyleBlocks";
+
+const removeUnsupportedBlocks: FilterEditorStateBeforeUpdateFn = (newState, { supports }) => {
+    // unstyle all core-blocks which are not supported
+    const blackListBlocks: DraftBlockType[] = ["paragraph", "header-four", "header-five", "header-six", "blockquote", "code-block", "atomic"]; // these are not supported at all by our rte
+
+    const supportsToBlockMap: Partial<Record<SuportedThings, DraftBlockType>> = {
+        "header-one": "header-one",
+        "header-two": "header-two",
+        "header-three": "header-three",
+        "ordered-list": "ordered-list-item",
+        "unordered-list": "unordered-list-item",
+    };
+    const supportsToTest = Object.keys(supportsToBlockMap) as SuportedThings[];
+    supportsToTest.forEach(support => {
+        if (!supports.includes(support) && supportsToBlockMap[support]) {
+            const blockType = supportsToBlockMap[support];
+            if (blockType) {
+                blackListBlocks.push(blockType);
+            }
+        }
+    });
+
+    return unstyleBlocks(blackListBlocks)(newState);
+};
+
+export default removeUnsupportedBlocks;

--- a/packages/react-admin-rte/src/core/filterEditor/removeUnsupportedEntities.ts
+++ b/packages/react-admin-rte/src/core/filterEditor/removeUnsupportedEntities.ts
@@ -1,0 +1,24 @@
+import { DraftBlockType, DraftEntityType, Editor as DraftJsEditor, EditorProps as DraftJsEditorProps } from "draft-js";
+import { FilterEditorStateBeforeUpdateFn, SuportedThings } from "../Rte";
+import { FilterEditorStateFn, InlineStyleType } from "../types";
+import removeEntities from "./utils/removeEntities";
+import unstyleBlocks from "./utils/unstyleBlocks";
+
+const removeUnsupportedEntities: FilterEditorStateBeforeUpdateFn = (newState, { supports }) => {
+    // remove links and images
+    return removeEntities(entity => {
+        const unsupportedCoreEntities: DraftEntityType[] = ["IMAGE", "TOKEN", "PHOTO"];
+        if (unsupportedCoreEntities.includes(entity.getType())) {
+            return false;
+        }
+
+        if (!supports.includes("link")) {
+            if (entity.getType() === "LINK") {
+                return false;
+            }
+        }
+        return true;
+    })(newState);
+};
+
+export default removeUnsupportedEntities;

--- a/packages/react-admin-rte/src/core/filterEditor/removeUnsupportedInlineStyles.ts
+++ b/packages/react-admin-rte/src/core/filterEditor/removeUnsupportedInlineStyles.ts
@@ -1,0 +1,29 @@
+import { FilterEditorStateBeforeUpdateFn, SuportedThings } from "../Rte";
+import { InlineStyleType } from "../types";
+import removeInlineStyles from "./utils/removeInlineStyles";
+
+const removeUnsupportedInlineStyles: FilterEditorStateBeforeUpdateFn = (newState, { supports }) => {
+    // unstyle all core-blocks which are not supported
+    const blackListInlineStyles: InlineStyleType[] = ["STRIKETHROUGH", "CODE"]; // these are not supported at all by our rte
+
+    const supportsToInlineStyleMap: Partial<Record<SuportedThings, InlineStyleType>> = {
+        bold: "BOLD",
+        italic: "ITALIC",
+        underline: "UNDERLINE",
+        sub: "SUB",
+        sup: "SUP",
+    };
+    const supportsToTest = Object.keys(supportsToInlineStyleMap) as SuportedThings[];
+    supportsToTest.forEach(support => {
+        if (!supports.includes(support) && supportsToInlineStyleMap[support]) {
+            const inlineStyle = supportsToInlineStyleMap[support];
+            if (inlineStyle) {
+                blackListInlineStyles.push(inlineStyle);
+            }
+        }
+    });
+
+    return removeInlineStyles(blackListInlineStyles)(newState);
+};
+
+export default removeUnsupportedInlineStyles;

--- a/packages/react-admin-rte/src/core/filterEditor/utils/manipulateEntityData.ts
+++ b/packages/react-admin-rte/src/core/filterEditor/utils/manipulateEntityData.ts
@@ -1,0 +1,41 @@
+import { EditorState, EntityInstance } from "draft-js";
+import { FilterEditorStateFn } from "../../types";
+
+type UpdateEntityDataFn = (entity: EntityInstance) => {} | undefined; // if object is returned the entity data is updated with this object
+
+// inspired by https://github.com/thibaudcolas/draftjs-filters/blob/31d89177090b815b968ac2d8ec95c89d975f1e44/src/lib/filters/entities.js#L179
+const manipulateEntityData: (updateEntityDataFn: UpdateEntityDataFn) => FilterEditorStateFn = updateEntityDataFn => nextState => {
+    const content = nextState.getCurrentContent();
+    const entities: Record<string, EntityInstance> = {};
+
+    content.getBlocksAsArray().forEach(block => {
+        if (block) {
+            block.findEntityRanges(
+                char => {
+                    const entityKey = char.getEntity();
+                    if (entityKey) {
+                        const entity = content.getEntity(entityKey);
+                        entities[entityKey] = entity;
+                    }
+                    return false; // irrelevant
+                },
+                () => {
+                    // no cb needed
+                },
+            );
+        }
+    });
+
+    Object.entries(entities).forEach(([key, entity]) => {
+        const maybeNewData = updateEntityDataFn(entity);
+        if (maybeNewData) {
+            content.replaceEntityData(key, maybeNewData);
+        }
+    });
+
+    return EditorState.set(nextState, {
+        currentContent: content,
+    });
+};
+
+export default manipulateEntityData;

--- a/packages/react-admin-rte/src/core/filterEditor/utils/removeEntities.ts
+++ b/packages/react-admin-rte/src/core/filterEditor/utils/removeEntities.ts
@@ -1,0 +1,37 @@
+import { CharacterMetadata, EditorState, EntityInstance } from "draft-js";
+import { FilterEditorStateFn } from "../../types";
+
+type FilterFn = (entity: EntityInstance) => boolean; // when function returns false the entity is removed
+
+// inspired by https://github.com/thibaudcolas/draftjs-filters/blob/31d89177090b815b968ac2d8ec95c89d975f1e44/src/lib/filters/entities.js#L77
+const removeEntities: (filterFn: FilterFn) => FilterEditorStateFn = filterFn => nextState => {
+    const content = nextState.getCurrentContent();
+    const blockMap = content.getBlockMap();
+
+    const blocks: any = blockMap.map(block => {
+        let altered = false;
+        const chars = block!.getCharacterList().map(char => {
+            if (!char) {
+                return undefined;
+            }
+            const entityKey = char.getEntity();
+            if (entityKey) {
+                const entity = content.getEntity(entityKey);
+                if (!filterFn(entity)) {
+                    altered = true;
+                    return CharacterMetadata.applyEntity(char, null);
+                }
+            }
+            return char;
+        });
+        return altered ? block!.set("characterList", chars) : block;
+    });
+
+    return EditorState.set(nextState, {
+        currentContent: content.merge({
+            blockMap: blockMap.merge(blocks),
+        }),
+    });
+};
+
+export default removeEntities;

--- a/packages/react-admin-rte/src/core/filterEditor/utils/removeInlineStyles.ts
+++ b/packages/react-admin-rte/src/core/filterEditor/utils/removeInlineStyles.ts
@@ -1,0 +1,38 @@
+import { CharacterMetadata, EditorState } from "draft-js";
+import { FilterEditorStateFn, InlineStyleType } from "../../types";
+
+type StyleBlacklist = InlineStyleType[];
+
+// inspired by export const filterInlineStyles = (
+const removeInlineStyles: (blockBlacklist: StyleBlacklist) => FilterEditorStateFn = blockBlacklist => nextState => {
+    const content = nextState.getCurrentContent();
+    const blockMap = content.getBlockMap();
+
+    const changedBlocks: any = blockMap.map(block => {
+        let altered = false;
+
+        const chars = block!.getCharacterList().map(char => {
+            let newChar = char!;
+
+            char!
+                .getStyle()
+                .filter(type => blockBlacklist.includes(type! as InlineStyleType))
+                .forEach(type => {
+                    altered = true;
+                    newChar = CharacterMetadata.removeStyle(newChar, type!);
+                });
+
+            return newChar;
+        });
+
+        return altered ? block!.set("characterList", chars) : block;
+    });
+
+    return EditorState.set(nextState, {
+        currentContent: content.merge({
+            blockMap: blockMap.merge(changedBlocks),
+        }),
+    });
+};
+
+export default removeInlineStyles;

--- a/packages/react-admin-rte/src/core/filterEditor/utils/unstyleBlocks.ts
+++ b/packages/react-admin-rte/src/core/filterEditor/utils/unstyleBlocks.ts
@@ -1,0 +1,27 @@
+import { EditorState } from "draft-js";
+import { FilterEditorStateFn } from "../../types";
+
+type BlockBlacklist = string[];
+
+// inspired by https://github.com/thibaudcolas/draftjs-filters/blob/master/src/lib/filters/blocks.js#L127
+const unstyleBlocks: (blockBlacklist: BlockBlacklist) => FilterEditorStateFn = blockBlacklist => nextState => {
+    const content = nextState.getCurrentContent();
+    const blockMap = content.getBlockMap();
+
+    const changedBlocks: any = blockMap
+        .filter(block => !block || blockBlacklist.includes(block.getType()))
+        .map(block => {
+            return block!.merge({
+                type: "unstyled",
+                depth: 0,
+            });
+        });
+
+    return EditorState.set(nextState, {
+        currentContent: content.merge({
+            blockMap: blockMap.merge(changedBlocks),
+        }),
+    });
+};
+
+export default unstyleBlocks;

--- a/packages/react-admin-rte/src/core/types.ts
+++ b/packages/react-admin-rte/src/core/types.ts
@@ -33,3 +33,5 @@ export interface IControlProps {
 }
 
 export type ToolbarButtonComponent = (props: IControlProps) => JSX.Element;
+
+export type FilterEditorStateFn = (nextState: EditorState) => EditorState;

--- a/packages/react-admin-rte/src/index.ts
+++ b/packages/react-admin-rte/src/index.ts
@@ -1,4 +1,4 @@
-export { default as Rte, IRteRef, IOptions as IRteOptions, IProps as IRteProps } from "./core/Rte";
+export { default as Rte, IRteRef, IOptions as IRteOptions, IProps as IRteProps, FilterEditorStateBeforeUpdateFn } from "./core/Rte";
 export { default as RteReadOnly, IOptions as IRteReadOnlyOptions, IProps as IRteReadOnlyProps } from "./core/RteReadOnly";
 export { default as makeRteApi, IMakeRteApiProps, OnDebouncedContentChangeFn, IRteApiProps } from "./core/makeRteApi";
 export { default as createRteField } from "./field/createRteField";
@@ -9,3 +9,12 @@ export { default as findEntityInCurrentSelection } from "./core/utils/findEntity
 
 export { default as LinkDecorator } from "./core/extension/Link/Decorator";
 export { default as ControlButton, IProps as IControlButtonProps } from "./core/Controls/ControlButton";
+
+export { default as filterEditorStateDefault } from "./core/filterEditor/default";
+export { default as filterEditorStateRemoveUnsupportedBlocks } from "./core/filterEditor/removeUnsupportedBlocks";
+export { default as filterEditorStateRemoveUnsupportedEntities } from "./core/filterEditor/removeUnsupportedEntities";
+export { default as filterEditorStateRemoveUnsupportedInlineStyles } from "./core/filterEditor/removeUnsupportedInlineStyles";
+export { default as filterEditorUtilsManipulateEntityData } from "./core/filterEditor/utils/manipulateEntityData";
+export { default as filterEditorUtilsRemoveEntities } from "./core/filterEditor/utils/removeEntities";
+export { default as filterEditorUtilsRemoveInlineStyles } from "./core/filterEditor/utils/removeInlineStyles";
+export { default as filterEditorUtilsUnstyleBlocks } from "./core/filterEditor/utils/unstyleBlocks";

--- a/packages/react-admin-stories/src/react-admin-rte/RteAllOptions.tsx
+++ b/packages/react-admin-stories/src/react-admin-rte/RteAllOptions.tsx
@@ -58,9 +58,10 @@ export const rteOptions: IRteOptions = {
         editorKey: "id-for-ssr",
         readOnly: false,
         spellCheck: true,
-        stripPastedStyles: true,
+        stripPastedStyles: false,
         tabIndex: 0,
     },
+    filterEditorStateBeforeUpdate: state => state, // removes default filter
 };
 
 const [useRteApi] = makeRteApi<ContentFormat>(makeApiOptions);

--- a/packages/react-admin-stories/src/react-admin-rte/RteCustom.tsx
+++ b/packages/react-admin-stories/src/react-admin-rte/RteCustom.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { PrintEditorState, RteLayout, useAutoFocus } from "./helper";
 
 const rteOptions: IRteOptions = {
-    supports: ["bold", "italic", "header-one", "header-two", "ordered-list", "unordered-list"],
+    supports: ["italic", "header-one", "header-two", "ordered-list", "unordered-list"],
     listLevelMax: 3,
 };
 
@@ -20,6 +20,11 @@ function Story() {
 
     return (
         <>
+            Copy and paste content from{" "}
+            <a target="_blank" href="https://docs.google.com/document/d/1YjqkIMC3q4jAzy__-S4fb6mC_w9EssmA6aZbGYWFv80/edit#">
+                https://docs.google.com/document/d/1YjqkIMC3q4jAzy__-S4fb6mC_w9EssmA6aZbGYWFv80/edit#
+            </a>{" "}
+            to test filtering
             <RteLayout>
                 <Rte value={editorState} onChange={setEditorState} ref={editorRef} options={rteOptions} />
             </RteLayout>

--- a/packages/react-admin-stories/src/react-admin-rte/RteFilterContent.tsx
+++ b/packages/react-admin-stories/src/react-admin-rte/RteFilterContent.tsx
@@ -1,0 +1,54 @@
+import { storiesOf } from "@storybook/react";
+import {
+    FilterEditorStateBeforeUpdateFn,
+    filterEditorStateDefault,
+    filterEditorUtilsManipulateEntityData,
+    IRteRef,
+    makeRteApi,
+    Rte,
+} from "@vivid-planet/react-admin-rte";
+import { EditorState, EntityInstance } from "draft-js";
+import * as React from "react";
+import { PrintEditorState, RteLayout, useAutoFocus } from "./helper";
+
+const [useRteApi] = makeRteApi();
+
+const filterEditorStateBeforeUpdate: FilterEditorStateBeforeUpdateFn = (nextState: EditorState, ctx) => {
+    const shouldFilter = nextState.getLastChangeType() === "insert-fragment";
+
+    // this fn will strip out all attributes from link data and add 2 new attributes
+    const changeLinkData = filterEditorUtilsManipulateEntityData((entity: EntityInstance) => {
+        const data = entity.getData();
+        const isLink = "LINK" === entity.getType();
+        if (isLink && !data.linkType && data.url) {
+            return { linkType: "external", targetUrl: data.url };
+        }
+        return undefined;
+    });
+    if (shouldFilter) {
+        return changeLinkData(filterEditorStateDefault(nextState, ctx)); // apply default filter and then manipulate data in LINKS
+    }
+    return filterEditorStateDefault(nextState, ctx);
+};
+
+function Story() {
+    const { editorState, setEditorState } = useRteApi();
+
+    // focus the editor to see the cursor immediately
+    const editorRef = React.useRef<IRteRef>();
+    useAutoFocus(editorRef);
+
+    return (
+        <>
+            <div style={{ padding: "10px" }}>
+                <a href="https://google.com">Copy and paste this link into the editor</a>, and see in the editorstate that the link-data has changed
+            </div>
+            <RteLayout>
+                <Rte value={editorState} onChange={setEditorState} ref={editorRef} options={{ filterEditorStateBeforeUpdate }} />
+            </RteLayout>
+            <PrintEditorState editorState={editorState} />
+        </>
+    );
+}
+
+storiesOf("react-admin-rte", module).add("Rte, filter content", () => <Story />);


### PR DESCRIPTION
Wenn entities, blocks und styles nicht im supports-array sind werden diese entities, blocks und styles beim content-pasten nicht berücksichtigt bzw auf einen unformatierten Block umgewandelt.