### PR TITLE
New api for StackSwitch using an hook that returns the api and a StackSwitch component Version 2

### DIFF
--- a/packages/react-admin-core/src/DeleteMutation.tsx
+++ b/packages/react-admin-core/src/DeleteMutation.tsx
@@ -24,7 +24,7 @@ export function DeleteMutation(props: IProps) {
     return (
         <React.Fragment>
             {props.children(
-                (options) => {
+                options => {
                     setDialogOpen(true);
                     setPendingVariables(options.variables);
                 },

--- a/packages/react-admin-core/src/EditDialog.tsx
+++ b/packages/react-admin-core/src/EditDialog.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { DirtyHandler } from "./DirtyHandler";
 import { DirtyHandlerApiContext, IDirtyHandlerApi } from "./DirtyHandlerApiContext";
 import { EditDialogApiContext, IEditDialogApi } from "./EditDialogApiContext";
+import { ISelectionApi } from "./SelectionApi";
 import { SelectionRoute } from "./SelectionRoute";
 
 interface ITitle {

--- a/packages/react-admin-core/src/EditDialog.tsx
+++ b/packages/react-admin-core/src/EditDialog.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import { DirtyHandler } from "./DirtyHandler";
 import { DirtyHandlerApiContext, IDirtyHandlerApi } from "./DirtyHandlerApiContext";
 import { EditDialogApiContext, IEditDialogApi } from "./EditDialogApiContext";
-import { ISelectionApi } from "./SelectionApi";
 import { SelectionRoute } from "./SelectionRoute";
 
 interface ITitle {

--- a/packages/react-admin-core/src/FinalForm.tsx
+++ b/packages/react-admin-core/src/FinalForm.tsx
@@ -63,7 +63,7 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
 
         function submit(event: any) {
             if (!formRenderProps.dirty) return;
-            return new Promise((resolve) => {
+            return new Promise(resolve => {
                 Promise.resolve(formRenderProps.handleSubmit(event)).then(
                     () => {
                         if (formRenderProps.submitSucceeded) {
@@ -72,7 +72,7 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
                             resolve(formRenderProps.submitErrors);
                         }
                     },
-                    (error) => {
+                    error => {
                         resolve(error);
                     },
                 );
@@ -143,7 +143,7 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
         if (ret === undefined) return ret;
 
         return Promise.resolve(ret)
-            .then((data) => {
+            .then(data => {
                 // setTimeout is required because of https://github.com/final-form/final-form/pull/229
                 setTimeout(() => {
                     if (props.mode === "add") {
@@ -169,11 +169,11 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
                 return data;
             })
             .then(
-                (data) => {
+                data => {
                     // for final-form undefined means success, an obj means error
                     return undefined;
                 },
-                (error) => {
+                error => {
                     // resolve with FORM_ERROR
                     return Promise.resolve({
                         [FORM_ERROR]: error.toString(),

--- a/packages/react-admin-core/src/router/ConfirmationDialog.tsx
+++ b/packages/react-admin-core/src/router/ConfirmationDialog.tsx
@@ -1,4 +1,4 @@
-import { Button,Dialog,DialogActions ,DialogTitle,Typography} from "@material-ui/core";
+import { Button, Dialog, DialogActions, DialogTitle, Typography } from "@material-ui/core";
 import * as React from "react";
 
 interface IProps {

--- a/packages/react-admin-core/src/stack/Switch.tsx
+++ b/packages/react-admin-core/src/stack/Switch.tsx
@@ -38,24 +38,27 @@ function useUuid() {
 }
 
 export function useStackSwitch() {
-    let injectedApi: IStackSwitchApi | null = null;
+    const apiRef = React.useRef<IStackSwitchApi>();
     const id = useUuid();
     const api: IStackSwitchApi = {
         id,
         activatePage: (pageName: string, payload: string, subUrl?: string) => {
-            injectedApi?.activatePage(pageName, payload, subUrl);
+            apiRef.current?.activatePage(pageName, payload, subUrl);
         },
         updatePageBreadcrumbTitle: (title?: string) => {
-            injectedApi?.updatePageBreadcrumbTitle(title);
+            apiRef.current?.updatePageBreadcrumbTitle(title);
         }
     }
+    const StackSwitchWithHookProps = React.useMemo(() => {
+        return (props: IProps) => {
+            return <StackSwitch {...props} id={id} injectApi={(a: IStackSwitchApi) => {
+                apiRef.current = a;
+            }} />
+        };
+    }, [id, apiRef]);
     return {
         api,
-        StackSwitch: (props: IProps) => {
-            return <StackSwitch {...props} id={id} injectApi={(a: IStackSwitchApi) => {
-                injectedApi = a;
-            }} />
-        }
+        StackSwitch: StackSwitchWithHookProps
     }
 }
 

--- a/packages/react-admin-stories/src/react-admin-core/StackNested.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackNested.tsx
@@ -1,6 +1,6 @@
 import { Typography } from "@material-ui/core";
 import { storiesOf } from "@storybook/react";
-import { Stack, StackPage, StackSwitch, StackSwitchApiContext } from "@vivid-planet/react-admin-core";
+import { Stack, StackPage, StackSwitchApiContext, useStackSwitch } from "@vivid-planet/react-admin-core";
 import * as React from "react";
 import { Redirect, Route, Switch } from "react-router";
 import StoryRouter from "storybook-react-router";
@@ -19,6 +19,7 @@ function Page1() {
 }
 
 function Page2() {
+    const { StackSwitch } = useStackSwitch();
     return (
         <Stack topLevelTitle="Stack Nested">
             <StackSwitch>
@@ -32,6 +33,7 @@ function Page2() {
 }
 
 function Story() {
+    const { StackSwitch } = useStackSwitch();
     return (
         <Stack topLevelTitle="Stack">
             <StackSwitch>

--- a/packages/react-admin-stories/src/react-admin-core/StackNested.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackNested.tsx
@@ -19,7 +19,7 @@ function Page1() {
 }
 
 function Page2() {
-    const { StackSwitch } = useStackSwitch();
+    const { StackSwitch } = useStackSwitch({ initialPage: "page1" });
     return (
         <Stack topLevelTitle="Stack Nested">
             <StackSwitch>
@@ -33,7 +33,7 @@ function Page2() {
 }
 
 function Story() {
-    const { StackSwitch } = useStackSwitch();
+    const { StackSwitch } = useStackSwitch({ initialPage: "page1" });
     return (
         <Stack topLevelTitle="Stack">
             <StackSwitch>

--- a/packages/react-admin-stories/src/react-admin-core/StackPageTitle.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackPageTitle.tsx
@@ -9,13 +9,23 @@ function Page2() {
     const ref = React.useRef<IStackSwitchApi>();
     return (
         <div>
-            <button onClick={() => { setCounter(counter+1); }}>{counter}</button>
+            <button
+                onClick={() => {
+                    setCounter(counter + 1);
+                }}
+            >
+                {counter}
+            </button>
             <StackSwitch ref={ref}>
                 <StackPage name="page2-1">
                     <div>page2-1</div>
-                    <button onClick={() => {
-                        ref.current?.activatePage("page2-2", "foo");
-                    }}>page2-2</button>   
+                    <button
+                        onClick={() => {
+                            ref.current?.activatePage("page2-2", "foo");
+                        }}
+                    >
+                        page2-2
+                    </button>
                 </StackPage>
                 <StackPage name="page2-2">
                     <StackPageTitle title={`Foobar Page2-2: ${counter}`}>
@@ -31,18 +41,32 @@ function Story() {
     const [counter, setCounter] = React.useState(0);
     const ref = React.useRef<IStackSwitchApi>();
     return (
-        <div>      
-            <button onClick={() => { setCounter(counter+1); }}>{counter}</button>
+        <div>
+            <button
+                onClick={() => {
+                    setCounter(counter + 1);
+                }}
+            >
+                {counter}
+            </button>
             <Stack topLevelTitle="Stack">
                 <StackSwitch ref={ref}>
                     <StackPage name="page1">
                         <div>page1</div>
-                        <button onClick={() => {
-                            ref.current?.activatePage("page2", "foo");
-                        }}>page2</button>  
-                        <button onClick={() => {
-                            ref.current?.activatePage("page3", "foo");
-                        }}>page3</button>  
+                        <button
+                            onClick={() => {
+                                ref.current?.activatePage("page2", "foo");
+                            }}
+                        >
+                            page2
+                        </button>
+                        <button
+                            onClick={() => {
+                                ref.current?.activatePage("page3", "foo");
+                            }}
+                        >
+                            page3
+                        </button>
                     </StackPage>
                     <StackPage name="page2">
                         <StackPageTitle title={`Foobar Page2: ${counter}`}>
@@ -79,4 +103,3 @@ function App() {
 storiesOf("react-admin-core", module)
     .addDecorator(StoryRouter())
     .add("Stack Page Title", () => <App />);
-

--- a/packages/react-admin-stories/src/react-admin-core/StackPageTitle.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackPageTitle.tsx
@@ -1,12 +1,12 @@
 import { storiesOf } from "@storybook/react";
-import { IStackSwitchApi, Stack, StackPage, StackPageTitle, StackSwitch } from "@vivid-planet/react-admin-core";
+import { IStackSwitchApi, Stack, StackPage, StackPageTitle, useStackSwitch } from "@vivid-planet/react-admin-core";
 import * as React from "react";
 import { Redirect, Route, Switch } from "react-router";
 import StoryRouter from "storybook-react-router";
 
 function Page2() {
     const [counter, setCounter] = React.useState(0);
-    const ref = React.useRef<IStackSwitchApi>();
+    const { StackSwitch, api } = useStackSwitch();
     return (
         <div>
             <button
@@ -16,12 +16,12 @@ function Page2() {
             >
                 {counter}
             </button>
-            <StackSwitch ref={ref}>
+            <StackSwitch>
                 <StackPage name="page2-1">
                     <div>page2-1</div>
                     <button
                         onClick={() => {
-                            ref.current?.activatePage("page2-2", "foo");
+                            api.activatePage("page2-2", "foo");
                         }}
                     >
                         page2-2
@@ -39,7 +39,7 @@ function Page2() {
 
 function Story() {
     const [counter, setCounter] = React.useState(0);
-    const ref = React.useRef<IStackSwitchApi>();
+    const { StackSwitch, api } = useStackSwitch();
     return (
         <div>
             <button
@@ -50,19 +50,19 @@ function Story() {
                 {counter}
             </button>
             <Stack topLevelTitle="Stack">
-                <StackSwitch ref={ref}>
+                <StackSwitch>
                     <StackPage name="page1">
                         <div>page1</div>
                         <button
                             onClick={() => {
-                                ref.current?.activatePage("page2", "foo");
+                                api.activatePage("page2", "foo");
                             }}
                         >
                             page2
                         </button>
                         <button
                             onClick={() => {
-                                ref.current?.activatePage("page3", "foo");
+                                api.activatePage("page3", "foo");
                             }}
                         >
                             page3

--- a/packages/react-admin-stories/src/react-admin-core/StackPageTitle.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackPageTitle.tsx
@@ -6,7 +6,7 @@ import StoryRouter from "storybook-react-router";
 
 function Page2() {
     const [counter, setCounter] = React.useState(0);
-    const { StackSwitch, api } = useStackSwitch();
+    const { StackSwitch, api } = useStackSwitch({ initialPage: "page2-1" });
     return (
         <div>
             <button
@@ -39,7 +39,7 @@ function Page2() {
 
 function Story() {
     const [counter, setCounter] = React.useState(0);
-    const { StackSwitch, api } = useStackSwitch();
+    const { StackSwitch, api } = useStackSwitch({ initialPage: "page1" });
     return (
         <div>
             <button

--- a/packages/react-admin-stories/src/react-admin-core/StackPageTitle.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackPageTitle.tsx
@@ -1,0 +1,82 @@
+import { storiesOf } from "@storybook/react";
+import { IStackSwitchApi, Stack, StackPage, StackPageTitle, StackSwitch } from "@vivid-planet/react-admin-core";
+import * as React from "react";
+import { Redirect, Route, Switch } from "react-router";
+import StoryRouter from "storybook-react-router";
+
+function Page2() {
+    const [counter, setCounter] = React.useState(0);
+    const ref = React.useRef<IStackSwitchApi>();
+    return (
+        <div>
+            <button onClick={() => { setCounter(counter+1); }}>{counter}</button>
+            <StackSwitch ref={ref}>
+                <StackPage name="page2-1">
+                    <div>page2-1</div>
+                    <button onClick={() => {
+                        ref.current?.activatePage("page2-2", "foo");
+                    }}>page2-2</button>   
+                </StackPage>
+                <StackPage name="page2-2">
+                    <StackPageTitle title={`Foobar Page2-2: ${counter}`}>
+                        <div>page2-2</div>
+                    </StackPageTitle>
+                </StackPage>
+            </StackSwitch>
+        </div>
+    );
+}
+
+function Story() {
+    const [counter, setCounter] = React.useState(0);
+    const ref = React.useRef<IStackSwitchApi>();
+    return (
+        <div>      
+            <button onClick={() => { setCounter(counter+1); }}>{counter}</button>
+            <Stack topLevelTitle="Stack">
+                <StackSwitch ref={ref}>
+                    <StackPage name="page1">
+                        <div>page1</div>
+                        <button onClick={() => {
+                            ref.current?.activatePage("page2", "foo");
+                        }}>page2</button>  
+                        <button onClick={() => {
+                            ref.current?.activatePage("page3", "foo");
+                        }}>page3</button>  
+                    </StackPage>
+                    <StackPage name="page2">
+                        <StackPageTitle title={`Foobar Page2: ${counter}`}>
+                            <Page2 />
+                        </StackPageTitle>
+                    </StackPage>
+                    <StackPage name="page3">
+                        <StackPageTitle title={`Foobar Page3: ${counter}`}>
+                            <div>page3</div>
+                        </StackPageTitle>
+                    </StackPage>
+                </StackSwitch>
+            </Stack>
+        </div>
+    );
+}
+
+function App() {
+    return (
+        <div>
+            <p>This story is mainly for testing the StackPageTitle component under various situations.</p>
+            <Switch>
+                <Route exact path="/">
+                    <Redirect to="/foo" />
+                </Route>
+                <Route path="/foo">
+                    <Story />
+                </Route>
+            </Switch>
+        </div>
+    );
+}
+
+storiesOf("react-admin-core", module)
+    .addDecorator(StoryRouter())
+    .add("Stack Page Title", () => <App />);
+

--- a/packages/react-admin-stories/src/react-admin-core/StackRefApi.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackRefApi.tsx
@@ -1,0 +1,44 @@
+import { storiesOf } from "@storybook/react";
+import { IStackSwitchApi, Stack, StackPage, StackSwitch } from "@vivid-planet/react-admin-core";
+import * as React from "react";
+import { Redirect, Route, Switch } from "react-router";
+import StoryRouter from "storybook-react-router";
+
+function Story() {
+    // demonstrate how to access the StackSwitchApi in the component where StackSwich is created (useStackSwitchApi doesn't work)
+    const ref = React.useRef<IStackSwitchApi>(null);
+    return (
+        <div>
+            <button onClick={() => {
+                ref.current?.activatePage("page2", "foo");
+            }}>page2</button>
+            <Stack topLevelTitle="Stack">
+                <StackSwitch ref={ref}>
+                    <StackPage name="page1">
+                        <div>page1</div>
+                    </StackPage>
+                    <StackPage name="page2">
+                        <div>page2</div>
+                    </StackPage>
+                </StackSwitch>
+            </Stack>
+        </div>
+    );
+}
+
+function App() {
+    return (
+        <Switch>
+            <Route exact path="/">
+                <Redirect to="/foo" />
+            </Route>
+            <Route path="/foo">
+                <Story />
+            </Route>
+        </Switch>
+    );
+}
+
+storiesOf("react-admin-core", module)
+    .addDecorator(StoryRouter())
+    .add("Stack Ref Api", () => <App />);

--- a/packages/react-admin-stories/src/react-admin-core/StackRefApi.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackRefApi.tsx
@@ -5,7 +5,7 @@ import { Redirect, Route, Switch } from "react-router";
 import StoryRouter from "storybook-react-router";
 
 function Story() {
-    const { StackSwitch, api } = useStackSwitch();
+    const { StackSwitch, api } = useStackSwitch({ initialPage: "page1" });
     // demonstrate how to access the StackSwitchApi in the component where StackSwich is created (useStackSwitchApi doesn't work)
     return (
         <div>

--- a/packages/react-admin-stories/src/react-admin-core/StackRefApi.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackRefApi.tsx
@@ -1,23 +1,23 @@
 import { storiesOf } from "@storybook/react";
-import { IStackSwitchApi, Stack, StackPage, StackSwitch } from "@vivid-planet/react-admin-core";
+import { Stack, StackPage, useStackSwitch } from "@vivid-planet/react-admin-core";
 import * as React from "react";
 import { Redirect, Route, Switch } from "react-router";
 import StoryRouter from "storybook-react-router";
 
 function Story() {
+    const { StackSwitch, api } = useStackSwitch();
     // demonstrate how to access the StackSwitchApi in the component where StackSwich is created (useStackSwitchApi doesn't work)
-    const ref = React.useRef<IStackSwitchApi>(null);
     return (
         <div>
             <button
                 onClick={() => {
-                    ref.current?.activatePage("page2", "foo");
+                    api.activatePage("page2", "foo");
                 }}
             >
                 page2
             </button>
             <Stack topLevelTitle="Stack">
-                <StackSwitch ref={ref}>
+                <StackSwitch>
                     <StackPage name="page1">
                         <div>page1</div>
                     </StackPage>

--- a/packages/react-admin-stories/src/react-admin-core/StackRefApi.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackRefApi.tsx
@@ -9,9 +9,13 @@ function Story() {
     const ref = React.useRef<IStackSwitchApi>(null);
     return (
         <div>
-            <button onClick={() => {
-                ref.current?.activatePage("page2", "foo");
-            }}>page2</button>
+            <button
+                onClick={() => {
+                    ref.current?.activatePage("page2", "foo");
+                }}
+            >
+                page2
+            </button>
             <Stack topLevelTitle="Stack">
                 <StackSwitch ref={ref}>
                     <StackPage name="page1">

--- a/packages/react-admin-stories/src/react-admin-core/StackTableFormQueryAtStack.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackTableFormQueryAtStack.tsx
@@ -150,7 +150,7 @@ function Story() {
         }),
     });
 
-    const { StackSwitch } = useStackSwitch();
+    const { StackSwitch } = useStackSwitch({ initialPage: "table" });
 
     return (
         <Stack topLevelTitle="Stack">

--- a/packages/react-admin-stories/src/react-admin-core/StackTableFormQueryAtStack.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackTableFormQueryAtStack.tsx
@@ -7,11 +7,11 @@ import {
     IFilterApi,
     Stack,
     StackPage,
-    StackSwitch,
     StackSwitchApiContext,
     Table,
     TableFilterFinalForm,
     TableQuery,
+    useStackSwitch,
     useTableQuery,
     useTableQueryFilter,
 } from "@vivid-planet/react-admin-core";
@@ -149,6 +149,8 @@ function Story() {
             totalCount: data.users.length,
         }),
     });
+
+    const { StackSwitch } = useStackSwitch();
 
     return (
         <Stack topLevelTitle="Stack">

--- a/packages/react-admin-stories/src/react-admin-core/StackTableFormQueryInTable.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackTableFormQueryInTable.tsx
@@ -6,12 +6,12 @@ import {
     FinalForm,
     Stack,
     StackPage,
-    StackSwitch,
     StackSwitchApiContext,
     Table,
     TableFilterFinalForm,
     TableQuery,
     usePersistedStateId,
+    useStackSwitch,
     useTableQuery,
     useTableQueryFilter,
 } from "@vivid-planet/react-admin-core";
@@ -155,6 +155,7 @@ function ExampleForm(props: IExampleFormProps) {
 
 function Story() {
     const persistedStateId = usePersistedStateId();
+    const { StackSwitch } = useStackSwitch();
     return (
         <Stack topLevelTitle="Stack">
             <StackSwitch>

--- a/packages/react-admin-stories/src/react-admin-core/StackTableFormQueryInTable.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/StackTableFormQueryInTable.tsx
@@ -155,7 +155,7 @@ function ExampleForm(props: IExampleFormProps) {
 
 function Story() {
     const persistedStateId = usePersistedStateId();
-    const { StackSwitch } = useStackSwitch();
+    const { StackSwitch } = useStackSwitch({ initialPage: "table" });
     return (
         <Stack topLevelTitle="Stack">
             <StackSwitch>

--- a/packages/react-admin-stories/src/react-admin-core/TableFilterClientside.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/TableFilterClientside.tsx
@@ -13,7 +13,10 @@ interface IFilterValues {
 }
 
 function Story() {
-    const data: IExampleRow[] = [{ id: 1, foo1: "blub1", foo2: "blub2" }, { id: 2, foo1: "blub2", foo2: "blub1" }];
+    const data: IExampleRow[] = [
+        { id: 1, foo1: "blub1", foo2: "blub2" },
+        { id: 2, foo1: "blub2", foo2: "blub1" },
+    ];
 
     const filterApi = useTableQueryFilter<IFilterValues>({});
 

--- a/packages/react-admin-stories/src/react-admin-core/TableResponsive.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/TableResponsive.tsx
@@ -54,7 +54,10 @@ function Story() {
     const { width } = useWindowSize();
     const showSecondRow = width < 1024;
 
-    const data: IExampleRow[] = [{ id: 1, foo1: "blub", foo2: "blub", bar: "barr" }, { id: 2, foo1: "blub", foo2: "blub", bar: "barr" }];
+    const data: IExampleRow[] = [
+        { id: 1, foo1: "blub", foo2: "blub", bar: "barr" },
+        { id: 2, foo1: "blub", foo2: "blub", bar: "barr" },
+    ];
     return (
         <Table
             data={data}

--- a/packages/react-admin-stories/src/react-admin-core/TableSortClientside.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/TableSortClientside.tsx
@@ -9,7 +9,10 @@ interface IExampleRow {
 }
 
 function Story() {
-    const data: IExampleRow[] = [{ id: 1, foo1: "blub1", foo2: "blub2" }, { id: 2, foo1: "blub2", foo2: "blub1" }];
+    const data: IExampleRow[] = [
+        { id: 1, foo1: "blub1", foo2: "blub2" },
+        { id: 2, foo1: "blub2", foo2: "blub1" },
+    ];
 
     const sortApi = useTableQuerySort({
         columnName: "foo1",


### PR DESCRIPTION
alternative to #205, similar to #215

Instead of the ugly hack in #215 move the required props into the hook (it's only initialPage). Downside: initialPage is now required (before the first page was used as initialPage)