### PR TITLE
add a new hook api for EditDialog, Selection and SelectionRoute

### DIFF
--- a/packages/react-admin-core/src/EditDialog.tsx
+++ b/packages/react-admin-core/src/EditDialog.tsx
@@ -4,7 +4,7 @@ import { DirtyHandler } from "./DirtyHandler";
 import { DirtyHandlerApiContext, IDirtyHandlerApi } from "./DirtyHandlerApiContext";
 import { EditDialogApiContext, IEditDialogApi } from "./EditDialogApiContext";
 import { ISelectionApi } from "./SelectionApi";
-import { SelectionRoute } from "./SelectionRoute";
+import { useSelectionRoute } from "./SelectionRoute";
 
 interface ITitle {
     edit: string;
@@ -13,77 +13,100 @@ interface ITitle {
 
 interface IProps {
     title?: ITitle | string;
-    children: (injectedProps: { selectedId?: string; selectionMode?: "edit" | "add" }) => React.ReactNode;
 }
 
-const EditDialogInner: React.RefForwardingComponent<IEditDialogApi, IProps> = (
-    { children, title = { edit: "Bearbeiten", add: "Hinzufügen" } }: IProps,
-    ref,
-) => {
-    const selectionRef = React.useRef<SelectionRoute>(null);
+export function useEditDialog(): [React.ComponentType<IProps>, { id?: string; mode?: "edit" | "add" }, IEditDialogApi] {
+    const [ Selection, selection, selectionApi]  = useSelectionRoute();
+
     const openAddDialog = React.useCallback(() => {
-        if (selectionRef.current) selectionRef.current.selectionApi.handleAdd();
-    }, [selectionRef]);
+        selectionApi.handleAdd();
+    }, [selection]);
 
     const openEditDialog = React.useCallback(
         (id: string) => {
-            if (selectionRef.current) selectionRef.current.selectionApi.handleSelectId(id);
+            selectionApi.handleSelectId(id);
         },
-        [selectionRef],
+        [selection],
     );
 
-    const api: IEditDialogApi = React.useMemo(
-        () => ({
-            openAddDialog,
-            openEditDialog,
-        }),
-        [openAddDialog, openEditDialog],
-    );
-    React.useImperativeHandle(ref, () => api);
+    const api: IEditDialogApi = {
+        openAddDialog,
+        openEditDialog,
+    }
+    const EditDialogWithHookProps = React.useMemo(() => {
+        return (props: IProps) => {
+            return <Selection>
+                <EditDialogInner {...props} selection={selection} selectionApi={selectionApi} api={api} />
+            </Selection>;
+        };
+    }, [selection]);
+
+    return [EditDialogWithHookProps, selection, api];
+}
+
+interface IHookProps {
+    selection: {
+        id?: string;
+        mode?: "edit" | "add"
+    };
+    selectionApi: ISelectionApi
+    api: IEditDialogApi
+}
+
+const EditDialogInner: React.FunctionComponent<IProps & IHookProps> = ({ selection, selectionApi, api, title = { edit: "Bearbeiten", add: "Hinzufügen" }, children }) => {
 
     let dirtyHandlerApi: IDirtyHandlerApi | undefined;
     const handleSaveClick = () => {
         if (dirtyHandlerApi) {
             dirtyHandlerApi.submitBindings().then(() => {
-                selectionRef.current?.selectionApi.handleDeselect();
+                selectionApi.handleDeselect();
             });
         }
     };
 
     const handleCancelClick = () => {
-        selectionRef.current?.selectionApi.handleDeselect();
+        selectionApi.handleDeselect();
     };
 
     return (
         <EditDialogApiContext.Provider value={api}>
             <DirtyHandler>
-                <SelectionRoute ref={selectionRef}>
-                    {({ selectedId, selectionMode, selectionApi }) => (
-                        <Dialog open={!!selectionMode} onClose={handleCancelClick}>
-                            <div>
-                                <DialogTitle>{typeof title === "string" ? title : selectionMode === "edit" ? title.edit : title.add}</DialogTitle>
-                                <DialogContent>{children({ selectedId, selectionMode })}</DialogContent>
-                                <DialogActions>
-                                    <Button onClick={handleCancelClick} color="primary">
-                                        <Typography variant="button">Abbrechen</Typography>
-                                    </Button>
-                                    <DirtyHandlerApiContext.Consumer>
-                                        {injectedDirtyHandlerApi => {
-                                            dirtyHandlerApi = injectedDirtyHandlerApi; // TODO replace by ref on <DirtyHandler>
-                                            return (
-                                                <Button onClick={handleSaveClick} color="primary">
-                                                    <Typography variant="button">Speichern</Typography>
-                                                </Button>
-                                            );
-                                        }}
-                                    </DirtyHandlerApiContext.Consumer>
-                                </DialogActions>
-                            </div>
-                        </Dialog>
-                    )}
-                </SelectionRoute>
+                <Dialog open={!!selection.mode} onClose={handleCancelClick}>
+                    <div>
+                        <DialogTitle>{typeof title === "string" ? title : selection.mode === "edit" ? title.edit : title.add}</DialogTitle>
+                        <DialogContent>{children}</DialogContent>
+                        <DialogActions>
+                            <Button onClick={handleCancelClick} color="primary">
+                                <Typography variant="button">Abbrechen</Typography>
+                            </Button>
+                            <DirtyHandlerApiContext.Consumer>
+                                {injectedDirtyHandlerApi => {
+                                    dirtyHandlerApi = injectedDirtyHandlerApi; // TODO replace by ref on <DirtyHandler>
+                                    return (
+                                        <Button onClick={handleSaveClick} color="primary">
+                                            <Typography variant="button">Speichern</Typography>
+                                        </Button>
+                                    );
+                                }}
+                            </DirtyHandlerApiContext.Consumer>
+                        </DialogActions>
+                    </div>
+                </Dialog>
             </DirtyHandler>
         </EditDialogApiContext.Provider>
     );
+}
+
+interface IEditDialogHooklessProps extends IProps {
+    children: (injectedProps: { selectedId?: string; selectionMode?: "edit" | "add" }) => React.ReactNode;
+}
+
+const EditDialogHooklessInner: React.RefForwardingComponent<IEditDialogApi, IEditDialogHooklessProps> = (
+    { children, title = { edit: "Bearbeiten", add: "Hinzufügen" } },
+    ref,
+) => {
+    const [ EditDialogConfigured, selection, api ] = useEditDialog();
+    React.useImperativeHandle(ref, () => api);
+    return <EditDialogConfigured title={title}>{children({ selectedId: selection.id, selectionMode: selection.mode })}</EditDialogConfigured>;
 };
-export const EditDialog = React.forwardRef(EditDialogInner);
+export const EditDialog = React.forwardRef(EditDialogHooklessInner);

--- a/packages/react-admin-core/src/EditDialog.tsx
+++ b/packages/react-admin-core/src/EditDialog.tsx
@@ -20,13 +20,13 @@ export function useEditDialog(): [React.ComponentType<IProps>, { id?: string; mo
 
     const openAddDialog = React.useCallback(() => {
         selectionApi.handleAdd();
-    }, [selection]);
+    }, [selectionApi]);
 
     const openEditDialog = React.useCallback(
         (id: string) => {
             selectionApi.handleSelectId(id);
         },
-        [selection],
+        [selectionApi],
     );
 
     const api: IEditDialogApi = {

--- a/packages/react-admin-core/src/Selection.tsx
+++ b/packages/react-admin-core/src/Selection.tsx
@@ -1,54 +1,54 @@
 import * as React from "react";
-import { DirtyHandlerApiContext, IDirtyHandlerApi } from "./DirtyHandlerApiContext";
 import { ISelectionApi } from "./SelectionApi";
+
+interface IState {
+    id?: string;
+    mode?: "edit" | "add";
+}
+export function useSelection(): [{ id?: string; mode?: "edit" | "add" }, ISelectionApi] {
+    const [selection, setSelection] = React.useState<IState>({ id: undefined, mode: undefined });
+
+    const handleSelectId = React.useCallback(async (id: string) => {
+        setSelection({ id, mode: "edit" });
+    }, [setSelection]);
+
+    const handleDeselect = React.useCallback(async () => {
+        setSelection({ id: undefined, mode: undefined });
+    }, [setSelection]);
+
+    const handleAdd = React.useCallback(() => {
+        setSelection({ id: undefined, mode: "add" });
+    }, [setSelection]);
+
+    const api: ISelectionApi = React.useMemo(() => ({
+        handleSelectId,
+        handleDeselect,
+        handleAdd,
+    }), [handleSelectId, handleDeselect, handleAdd]);
+
+    return [{
+        id: selection.id,
+        mode: selection.mode
+    }, api];
+}
 
 export interface ISelectionRenderPropArgs {
     selectedId?: string;
     selectionMode?: "edit" | "add";
     selectionApi: ISelectionApi;
 }
+
 interface IProps {
     children: (injectedProps: ISelectionRenderPropArgs) => React.ReactNode;
 }
-interface IState {
-    selectedId?: string;
-    selectionMode?: "edit" | "add";
-}
-export class Selection extends React.Component<IProps, IState> {
-    private selectionApi: ISelectionApi;
-    private dirtyHandlerApi?: IDirtyHandlerApi;
-    constructor(props: IProps) {
-        super(props);
 
-        this.state = {
-            selectedId: undefined,
-            selectionMode: undefined,
-        };
-
-        this.selectionApi = {
-            handleSelectId: this.handleSelectId.bind(this),
-            handleDeselect: this.handleDeselect.bind(this),
-            handleAdd: this.handleAdd.bind(this),
-        };
-    }
-
-    public handleSelectId(id: string) {
-        this.setState({ selectedId: id, selectionMode: "edit" });
-    }
-
-    public handleDeselect() {
-        this.setState({ selectedId: undefined, selectionMode: undefined });
-    }
-
-    public handleAdd() {
-        this.setState({ selectedId: undefined, selectionMode: "add" });
-    }
-
-    public render() {
-        return this.props.children({
-            selectedId: this.state.selectedId,
-            selectionMode: this.state.selectionMode,
-            selectionApi: this.selectionApi,
-        });
-    }
+export function Selection({ children }: IProps) {
+    const [ selection, api ]  = useSelection();
+    return <>
+        {children({
+            selectedId: selection.id,
+            selectionMode: selection.mode,
+            selectionApi: api,
+        })}
+    </>;
 }

--- a/packages/react-admin-stories/src/react-admin-core/TableBesidesFormSelectionHooks.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/TableBesidesFormSelectionHooks.tsx
@@ -1,7 +1,6 @@
 import { ApolloProvider } from "@apollo/react-hooks";
 import { storiesOf } from "@storybook/react";
-import { DirtyHandler, FinalForm, ISelectionApi, Selected, SelectionRoute, Table, TableQuery, useTableQuery } from "@vivid-planet/react-admin-core";
-import { useSelectionRoute } from "@vivid-planet/react-admin-core/lib/SelectionRoute";
+import { DirtyHandler, FinalForm, ISelectionApi, Selected, Table, TableQuery, useSelectionRoute, useTableQuery } from "@vivid-planet/react-admin-core";
 import { Field, Input } from "@vivid-planet/react-admin-form";
 import { FixedLeftRightLayout } from "@vivid-planet/react-admin-layout";
 import { InMemoryCache } from "apollo-cache-inmemory";

--- a/packages/react-admin-stories/src/react-admin-core/TableBesidesFormSelectionHooks.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/TableBesidesFormSelectionHooks.tsx
@@ -1,6 +1,7 @@
 import { ApolloProvider } from "@apollo/react-hooks";
 import { storiesOf } from "@storybook/react";
 import { DirtyHandler, FinalForm, ISelectionApi, Selected, SelectionRoute, Table, TableQuery, useTableQuery } from "@vivid-planet/react-admin-core";
+import { useSelectionRoute } from "@vivid-planet/react-admin-core/lib/SelectionRoute";
 import { Field, Input } from "@vivid-planet/react-admin-form";
 import { FixedLeftRightLayout } from "@vivid-planet/react-admin-layout";
 import { InMemoryCache } from "apollo-cache-inmemory";
@@ -81,6 +82,7 @@ function ExampleForm(props: IExampleFormProps) {
 }
 
 function Story() {
+    const [ Selection, selection, selectionApi ] = useSelectionRoute();
     const { tableData, api, loading, error } = useTableQuery<IQueryData, {}>()(query, {
         resolveTableData: data => ({
             data: data.users,
@@ -92,22 +94,20 @@ function Story() {
 
     return (
         <DirtyHandler>
-            <SelectionRoute>
-                {({ selectedId, selectionMode, selectionApi }) => (
-                    <TableQuery api={api} loading={loading} error={error}>
-                        <FixedLeftRightLayout>
-                            <FixedLeftRightLayout.Left>
-                                <ExampleTable tableData={tableData} selectedId={selectedId} selectionApi={selectionApi} />
-                            </FixedLeftRightLayout.Left>
-                            <FixedLeftRightLayout.Right>
-                                <Selected selectionMode={selectionMode} selectedId={selectedId} rows={tableData.data}>
-                                    {(user, { selectionMode: selectedSelectionMode }) => <ExampleForm mode={selectedSelectionMode} user={user} />}
-                                </Selected>
-                            </FixedLeftRightLayout.Right>
-                        </FixedLeftRightLayout>
-                    </TableQuery>
-                )}
-            </SelectionRoute>
+            <Selection>
+                <TableQuery api={api} loading={loading} error={error}>
+                    <FixedLeftRightLayout>
+                        <FixedLeftRightLayout.Left>
+                            <ExampleTable tableData={tableData} selectedId={selection.id} selectionApi={selectionApi} />
+                        </FixedLeftRightLayout.Left>
+                        <FixedLeftRightLayout.Right>
+                            <Selected selectionMode={selection.mode} selectedId={selection.id} rows={tableData.data}>
+                                {(user, { selectionMode: selectedSelectionMode }) => <ExampleForm mode={selectedSelectionMode} user={user} />}
+                            </Selected>
+                        </FixedLeftRightLayout.Right>
+                    </FixedLeftRightLayout>
+                </TableQuery>
+            </Selection>
         </DirtyHandler>
     );
 }
@@ -143,4 +143,4 @@ storiesOf("react-admin-core", module)
         return <ApolloProvider client={client}>{story()}</ApolloProvider>;
     })
     .addDecorator(StoryRouter())
-    .add("Table Besides Form", () => <App />);
+    .add("Table Besides Form Selection Hooks", () => <App />);

--- a/packages/react-admin-stories/src/react-admin-core/TableEditDialogHooks.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/TableEditDialogHooks.tsx
@@ -1,0 +1,117 @@
+import { ApolloProvider } from "@apollo/react-hooks";
+import { Button, IconButton, Toolbar, Typography } from "@material-ui/core";
+import { Add as AddIcon, Edit as EditIcon } from "@material-ui/icons";
+import { storiesOf } from "@storybook/react";
+import { FinalForm, IEditDialogApi, Selected, Table, useEditDialog } from "@vivid-planet/react-admin-core";
+import { TextField } from "@vivid-planet/react-admin-final-form-material-ui";
+import { Field } from "@vivid-planet/react-admin-form";
+import { InMemoryCache } from "apollo-cache-inmemory";
+import ApolloClient from "apollo-client";
+import { ApolloLink } from "apollo-link";
+import { RestLink } from "apollo-link-rest";
+import * as React from "react";
+import StoryRouter from "storybook-react-router";
+
+interface IExampleRow {
+    id: number;
+    foo: string;
+    bar: string;
+}
+
+interface IEditFormProps {
+    row: IExampleRow;
+    mode: "edit" | "add";
+}
+function EditForm(props: IEditFormProps) {
+    return (
+        <FinalForm
+            mode={props.mode}
+            initialValues={props.row}
+            onSubmit={values => {
+                alert(JSON.stringify(values));
+            }}
+        >
+            <Field name="foo" component={TextField} type="text" label="Name" />
+        </FinalForm>
+    );
+}
+
+function Story() {
+    const data: IExampleRow[] = [
+        { id: 1, foo: "blub", bar: "blub" },
+        { id: 2, foo: "blub", bar: "blub" },
+    ];
+
+    const [ EditDialog, selection, api ] = useEditDialog();
+
+    return (
+        <>
+            <Toolbar>
+                <Button
+                    color="default"
+                    endIcon={<AddIcon />}
+                    onClick={ev => {
+                        api.openAddDialog();
+                    }}
+                >
+                    <Typography variant="button">Hinzufügen</Typography>
+                </Button>
+            </Toolbar>
+            <Table
+                data={data}
+                totalCount={data.length}
+                columns={[
+                    {
+                        name: "foo",
+                        header: "Foo",
+                    },
+                    {
+                        name: "bar",
+                        header: "Bar",
+                    },
+                    {
+                        name: "edit",
+                        header: "Edit",
+                        render: row => (
+                            <IconButton
+                                onClick={ev => {
+                                    api.openEditDialog(String(row.id));
+                                }}
+                            >
+                                <EditIcon />
+                            </IconButton>
+                        ),
+                    },
+                ]}
+            />
+
+            <EditDialog>
+                {selection.mode && (
+                    <Selected selectionMode={selection.mode} selectedId={selection.id} rows={data}>
+                        {(row, { selectionMode: sm }) => <EditForm mode={sm} row={row} />}
+                    </Selected>
+                )}
+            </EditDialog>
+        </>
+    );
+}
+
+storiesOf("react-admin-core", module)
+    .addDecorator(StoryRouter())
+    .addDecorator(story => {
+        const link = ApolloLink.from([
+            new RestLink({
+                uri: "https://jsonplaceholder.typicode.com/",
+            }),
+        ]);
+
+        const cache = new InMemoryCache();
+
+        const client = new ApolloClient({
+            link,
+            cache,
+        });
+
+        return <ApolloProvider client={client}>{story()}</ApolloProvider>;
+    })
+    .add("Table EditDialog Hooks", () => <Story />);


### PR DESCRIPTION
Similar to StackSwitch hook in #215
    
The old api stays compatible (uses hook internally)
    
examples:

    const [ EditDialog, selection, api ] = useEditDialog();
    const [ SelectionRoute, selection, api ] = useSelectionRoute();
    const [ selection, api ] = useSelection();
    
See stories for full examples
