### PR TITLE
Fix RouterTabs issue with child routes

### DIFF
--- a/packages/react-admin-stories/src/react-admin-core/RouterTabsNestedStack.tsx
+++ b/packages/react-admin-stories/src/react-admin-core/RouterTabsNestedStack.tsx
@@ -1,0 +1,43 @@
+import { Button } from "@material-ui/core";
+import { storiesOf } from "@storybook/react";
+import { RouterTab, RouterTabs, Stack, StackPage, StackSwitch, StackSwitchApiContext } from "@vivid-planet/react-admin-core";
+import * as React from "react";
+import StoryRouter from "storybook-react-router";
+
+function Story() {
+    return (
+        <Stack topLevelTitle="Root Stack">
+            <RouterTabs>
+                <RouterTab label="Page 1" path="">
+                    <Stack topLevelTitle="Nested Stack">
+                        <StackSwitch>
+                            <StackPage name="table">
+                                <StackSwitchApiContext.Consumer>
+                                    {stackApi => (
+                                        <Button color="primary" variant="contained" onClick={() => stackApi.activatePage("edit", "test")}>
+                                            Test
+                                        </Button>
+                                    )}
+                                </StackSwitchApiContext.Consumer>
+                            </StackPage>
+                            <StackPage name="edit" title="Edit">
+                                <RouterTabs>
+                                    <RouterTab label="Page 3" path="">
+                                        Page 3
+                                    </RouterTab>
+                                </RouterTabs>
+                            </StackPage>
+                        </StackSwitch>
+                    </Stack>
+                </RouterTab>
+                <RouterTab label="Page 2" path="/page2">
+                    Page 2
+                </RouterTab>
+            </RouterTabs>
+        </Stack>
+    );
+}
+
+storiesOf("react-admin-core", module)
+    .addDecorator(StoryRouter())
+    .add("RouterTabs with nested Stack", () => <Story />);


### PR DESCRIPTION
This fix resolves an issue where the default route would not be rendered when the path of the URL would not match exactly (e.g. a child route). This is done by removing the exact prop from the Route component and using a Switch instead. The Route component with the default path "" is rendered last to ensure that another, more specific route (e.g. "/page2") is picked first by the Switch, using the default route as a fallback.