### PR TITLE
Fix closing EditDialog after saving

### DIFF
--- a/packages/react-admin-core/src/DirtyHandlerApiContext.tsx
+++ b/packages/react-admin-core/src/DirtyHandlerApiContext.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 export interface IDirtyHandlerApiBinding {
     isDirty: () => boolean;
-    submit: () => void;
+    submit: () => Promise<void>;
     reset: () => void;
 }
 export interface IDirtyHandlerApi {

--- a/packages/react-admin-core/src/FinalForm.tsx
+++ b/packages/react-admin-core/src/FinalForm.tsx
@@ -26,6 +26,16 @@ interface IProps<FormValues = AnyObject> extends FormProps<FormValues> {
         buttonsContainer?: React.ComponentType;
     };
     renderButtons?: (formRenderProps: FormRenderProps<FormValues>) => React.ReactNode;
+
+    // override final-form onSubmit and remove callback as we don't support that (return pomise instead)
+    onSubmit: (
+        values: FormValues,
+        form: FormApi<FormValues>,
+      ) =>
+        | SubmissionErrors
+        | Promise<SubmissionErrors | undefined>
+        | undefined
+        | void
 }
 
 export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
@@ -47,8 +57,8 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
                     isDirty: () => {
                         return formRenderProps.form.getState().dirty;
                     },
-                    submit: () => {
-                        return submit(undefined);
+                    submit: async (): Promise<void> => {
+                        await formRenderProps.form.submit();
                     },
                     reset: () => {
                         formRenderProps.form.reset();
@@ -139,8 +149,9 @@ export function FinalForm<FormValues = AnyObject>(props: IProps<FormValues>) {
         if (stackApi) stackApi.goBack();
     }
 
-    function handleSubmit(values: FormValues, form: FormApi<FormValues>, callback?: (errors?: SubmissionErrors) => void) {
-        const ret = props.onSubmit(values, form, callback);
+    function handleSubmit(values: FormValues, form: FormApi<FormValues>) {
+        const ret = props.onSubmit(values, form);
+
         if (ret === undefined) return ret;
 
         return Promise.resolve(ret)


### PR DESCRIPTION
1. make dirty handler submit a promise so we can wait for it
2. remove weird callback parameter for onSubmit as final-form thought we will use it (see https://github.com/final-form/final-form/blob/master/src/FinalForm.js#L1149)

If you need async submit, use promise, anything else is old school and not supported by react-admin anymore.
(In theory is is an incompatible change)