### PR TITLE
Make react-admin Field support render function as expected

### DIFF
--- a/packages/react-admin/src/form/Field.tsx
+++ b/packages/react-admin/src/form/Field.tsx
@@ -35,18 +35,21 @@ export class Field<FieldValue = any, T extends HTMLElement = HTMLElement> extend
         const { children, component, name, label, required } = this.props;
         const UsedFieldContainer = this.props.fieldContainerComponent || FieldContainer;
 
-        if (component) {
-            return (
-                <UsedFieldContainer label={label} required={required}>
-                    {React.createElement(component, { ...rest, input, meta })}
-                    {(meta.error || meta.submitError) && meta.touched && <FormHelperText error>{meta.error || meta.submitError}</FormHelperText>}
-                </UsedFieldContainer>
-            );
-        } else {
-            if (typeof children !== "function") {
-                throw new Error(`Warning: Must specify either a render function as children, or a component prop to ${name}`);
+        function render() {
+            if (component) {
+                return React.createElement(component, { ...rest, input, meta });
+            } else {
+                if (typeof children !== "function") {
+                    throw new Error(`Warning: Must specify either a render function as children, or a component prop to ${name}`);
+                }
+                return children({ input, meta });
             }
-            return children({ input, meta });
         }
+        return (
+            <UsedFieldContainer label={label} required={required}>
+                {render()}
+                {(meta.error || meta.submitError) && meta.touched && <FormHelperText error>{meta.error || meta.submitError}</FormHelperText>}
+            </UsedFieldContainer>
+        );
     }
 }


### PR DESCRIPTION
Before if render function was used no label/error/etc was rendered, now that is rendered like for component prop.
Incompatible change, if you need the old behaviour use final-form Field.

Usage example:
```
<Field name="foo" label="Foo">
  {(props) => <FinalFormInput {...props} />
</Field>
```

Advantages:
- full typechecks for input
- possibility to render children or any other elements

Disadvantage:
- More code