### PR TITLE
docs: add changelog.md; add highlights for version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 18. Dec 2020
+
+This version ist the first stable version.
+
+### Highlights
+
+-   Renamed from react-admin to comet-admin
+-   Consolidated react-admin-core, fetch-provider, file-icons, react-admin-final-form-material-ui, react-admin-form, react-admin-layout and react-admin-mui into comet-admin
+-   Removed date-fns in favor of react-intl
+-   Removed exports for styled and css from material-ui
+-   Moved react-select to own package comet-admin-react-select
+-   Make comet-admin translateable with react-intl
+-   Switched form TSLint to ESLint
+-   Updated apollo & graphql
+-   FinalForm wrappers (e.g. Checkbox, Input, ...) are now prefixed with FinalForm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,18 @@ This version ist the first stable version.
 
 ### Highlights
 
--   Renamed from react-admin to comet-admin
--   Consolidated react-admin-core, fetch-provider, file-icons, react-admin-final-form-material-ui, react-admin-form, react-admin-layout and react-admin-mui into comet-admin
--   Removed date-fns in favor of react-intl
--   Removed exports for styled and css from material-ui
--   Moved react-select to own package comet-admin-react-select
+-   Renamed from react-admin to comet-admin (!!!)
 -   Make comet-admin translateable with react-intl
--   Switched form TSLint to ESLint
--   Updated apollo & graphql
+-   Updated apollo
+
+### Incompatible Changes
+
+-   Restructured packages:
+    -   Consolidated react-admin-core, fetch-provider, file-icons, react-admin-final-form-material-ui, react-admin-form, react-admin-layout and react-admin-mui into comet-admin
+    -   Moved react-select to own package comet-admin-react-select
+-   Removed date-fns for date formatting in favor of react-intl
+-   Removed exports for styled and css, use styled-components directly
 -   FinalForm wrappers (e.g. Checkbox, Input, ...) are now prefixed with FinalForm
+
+### Internal Changes
+-   Switched form TSLint to ESLint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This version ist the first stable version.
 ### Highlights
 
 -   Renamed from react-admin to comet-admin (!!!)
--   Make comet-admin translateable with react-intl
+-   Made comet-admin translateable with react-intl
 -   Updated apollo
 
 ### Incompatible Changes


### PR DESCRIPTION
Migration-Guide will be added after pre-release of 1.0.0.

closes #240 